### PR TITLE
Test global interface override

### DIFF
--- a/packages/core/src/breakpoints/Breakpoints.tsx
+++ b/packages/core/src/breakpoints/Breakpoints.tsx
@@ -1,4 +1,4 @@
-export type Breakpoints = {
+export type DefaultBreakpointType = {
   xs: number;
   sm: number;
   md: number;
@@ -6,7 +6,21 @@ export type Breakpoints = {
   xl: number;
 };
 
-const breakpoints: Breakpoints = {
+declare global {
+  interface BreakpointsType extends Record<string, never> {}
+}
+
+export type Breakpoints<T = BreakpointsType> = T extends Record<string, never>
+  ? DefaultBreakpointType
+  : T;
+
+type CustomBreakpoints = Breakpoints<{ mobile: number }>;
+// expected TS Error: Property 'mobile' is missing in type '{}' but required in type '{ mobile: number; }'.ts(2741)
+const C: CustomBreakpoints = {};
+// expected TS Error: Type '{}' is missing the following properties from type 'DefaultBreakpointType': xs, sm, md, lg, xlts(2739)
+const B: Breakpoints = {};
+
+const breakpoints = {
   xs: 0,
   sm: 600,
   md: 960,

--- a/playground/theme-editor-app/src/App.tsx
+++ b/playground/theme-editor-app/src/App.tsx
@@ -2,11 +2,23 @@ import { BrowserRouter } from "react-router-dom";
 import { ThemeEditorApp } from "./ThemeEditorApp";
 
 import "./App.css";
+import { GridItem } from "@jpmorganchase/uitk-lab";
+
+declare global {
+  interface BreakpointsType {
+    mobile: string;
+  }
+}
 
 function App(): JSX.Element {
   return (
     <BrowserRouter>
       <ThemeEditorApp />
+
+      {/* BreakpointsType override is not taken into account */}
+      <GridItem colSpan={{ mobile: 1 }} rowSpan={{ mobile: 2 }}>
+        a
+      </GridItem>
     </BrowserRouter>
   );
 }


### PR DESCRIPTION
Try global interface override based on https://github.com/jpmorganchase/ui-toolkit-staging/pull/57#issuecomment-1109556421

The two lines in `packages/core/src/breakpoints/Breakpoints.tsx` has expected TS error

But when simulating in `playground/theme-editor-app/src/App.tsx`, it doesn't work.