### PR TITLE
Remove unneeded default export from Swatch

### DIFF
--- a/packages/lab/src/color-chooser/Swatch.tsx
+++ b/packages/lab/src/color-chooser/Swatch.tsx
@@ -94,6 +94,3 @@ export const Swatch = ({
     />
   );
 };
-
-// export default withHandleFocus(Swatch);
-export default Swatch;


### PR DESCRIPTION
Resolve below build warning

> Entry module "packages/lab/src/color-chooser/Swatch.tsx" is using named and default exports together. Consumers of your bundle will have to use `chunk["default"]` to access the default export, which may not be what you want. Use `output.exports: "named"` to disable this warning