### PR TITLE
Allow @types/react 18 peer dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,7 +8,7 @@
     "**/*.css.js"
   ],
   "peerDependencies": {
-    "@types/react": "^16.8.6 || ^17.0.0",
+    "@types/react": ">=16.8.6",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"
   },

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -8,7 +8,7 @@
     "build": "node ./scripts/generateIconComponent.js '*.svg' && node ./scripts/generateIconIndex.js"
   },
   "peerDependencies": {
-    "@types/react": "^16.8.6 || ^17.0.0",
+    "@types/react": ">=16.8.6",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"
   },

--- a/packages/lab/package.json
+++ b/packages/lab/package.json
@@ -8,7 +8,7 @@
     "**/*.css.js"
   ],
   "peerDependencies": {
-    "@types/react": "^16.8.6 || ^17.0.0",
+    "@types/react": ">=16.8.6",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3257,7 +3257,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jpmorganchase/uitk-core@workspace:packages/core"
   peerDependencies:
-    "@types/react": ^16.8.6 || ^17.0.0
+    "@types/react": ">=16.8.6"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
   peerDependenciesMeta:
@@ -3274,7 +3274,7 @@ __metadata:
     htmlparser2: ^7.2.0
     mustache: ^4.2.0
   peerDependencies:
-    "@types/react": ^16.8.6 || ^17.0.0
+    "@types/react": ">=16.8.6"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
   peerDependenciesMeta:
@@ -3287,7 +3287,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jpmorganchase/uitk-lab@workspace:packages/lab"
   peerDependencies:
-    "@types/react": ^16.8.6 || ^17.0.0
+    "@types/react": ">=16.8.6"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
   peerDependenciesMeta:


### PR DESCRIPTION
We don't want to block users to use react 18, otherwise something like below will happen

> npm ERR! code ERESOLVE
> npm ERR! ERESOLVE could not resolve
> npm ERR! 
> npm ERR! While resolving: @jpmorganchase/uitk-core@0.1.0
> npm ERR! Found: @types/react@18.0.9
> npm ERR! node_modules/@types/react
> npm ERR!   @types/react@"*" from @types/react-dom@18.0.5
> npm ERR!   node_modules/@types/react-dom
> npm ERR!     dev @types/react-dom@"^18.0.0" from the root project
> npm ERR!   dev @types/react@"^18.0.0" from the root project
> npm ERR! 
> npm ERR! Could not resolve dependency:
> npm ERR! peerOptional @types/react@"^16.8.6 || ^17.0.0" from @jpmorganchase/uitk-core@0.1.0