### PR TITLE
allow allrenderer and docgrid styling to be controlled

### DIFF
--- a/docs/components/AllRenderer.tsx
+++ b/docs/components/AllRenderer.tsx
@@ -16,9 +16,15 @@ import { BackgroundBlock } from "./BackgroundBlock";
  * ```
  */
 
-export const AllRenderer = ({ children }: { children: ReactElement }) => {
+export const AllRenderer = ({
+  children,
+  className,
+}: {
+  children: ReactElement;
+  className?: string;
+}): JSX.Element => {
   return (
-    <DocGrid>
+    <DocGrid className={className}>
       {DensityValues.map((d, i) => {
         return (
           <Fragment key={i}>

--- a/docs/components/DocGrid.css
+++ b/docs/components/DocGrid.css
@@ -14,8 +14,8 @@
   height: var(--uitkDocGrid-height, unset);
   gap: var(--uitkDocGrid-gap, var(--doc-grid-gap));
   grid-template-columns: repeat(2, auto);
-  padding-block-start: var(--doc-grid-padding-block-start);
-  padding-block-end: var(--doc-grid-padding-block-end);
+  padding-block-start: var(--uitkDocGrid-gap-padding-block-start, var(--doc-grid-padding-block-start));
+  padding-block-end: var(--uitkDocGrid-gap-padding-block-end, var(--doc-grid-padding-block-end));
   line-height: 1;
   width: var(--uitkDocGrid-width, auto);
 }

--- a/docs/components/DocGrid.css
+++ b/docs/components/DocGrid.css
@@ -14,8 +14,8 @@
   height: var(--uitkDocGrid-height, unset);
   gap: var(--uitkDocGrid-gap, var(--doc-grid-gap));
   grid-template-columns: repeat(2, auto);
-  padding-block-start: var(--uitkDocGrid-gap-padding-block-start, var(--doc-grid-padding-block-start));
-  padding-block-end: var(--uitkDocGrid-gap-padding-block-end, var(--doc-grid-padding-block-end));
+  padding-block-start: var(--uitkDocGrid-padding-block-start, var(--doc-grid-padding-block-start));
+  padding-block-end: var(--uitkDocGrid-padding-block-end, var(--doc-grid-padding-block-end));
   line-height: 1;
   width: var(--uitkDocGrid-width, auto);
 }

--- a/docs/components/DocGrid.tsx
+++ b/docs/components/DocGrid.tsx
@@ -5,14 +5,16 @@ import "./DocGrid.css";
 
 export const DocGrid = ({
   children,
+  className,
   textExample,
 }: {
   children: ReactNode;
+  className?: string;
   textExample?: boolean;
 }) => {
   return (
     <div
-      className={cx("uitkDocGrid", {
+      className={cx("uitkDocGrid", className, {
         ["uitkDocGrid-textExample"]: textExample,
       })}
     >


### PR DESCRIPTION
When DocGrid, AllRenderer are used in QA compare story to compare to a generated snapshot, we don't want the layout to vary based on global density setting, as the screenshot is fixed at medium density. 