### PR TITLE
Add @types/react-window to lab devDependencies

### DIFF
--- a/.changeset/honest-starfishes-remember.md
+++ b/.changeset/honest-starfishes-remember.md
@@ -1,0 +1,5 @@
+---
+"@jpmorganchase/uitk-lab": patch
+---
+
+Add @types/react-window to labs devDependencies

--- a/packages/lab/package.json
+++ b/packages/lab/package.json
@@ -7,6 +7,9 @@
     "**/*.css",
     "**/*.css.js"
   ],
+  "devDependencies": {
+    "@types/react-window": "^1.8.2"
+  },
   "peerDependencies": {
     "@types/react": ">=16.8.6",
     "react": ">=16.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3286,6 +3286,8 @@ __metadata:
 "@jpmorganchase/uitk-lab@workspace:packages/lab":
   version: 0.0.0-use.local
   resolution: "@jpmorganchase/uitk-lab@workspace:packages/lab"
+  dependencies:
+    "@types/react-window": ^1.8.2
   peerDependencies:
     "@types/react": ">=16.8.6"
     react: ">=16.8.0"


### PR DESCRIPTION
Without this, consumer running `tsc` would run into below error

> node_modules/@jpmorganchase/uitk-lab/dist-types/list/useListItem.d.ts:1:41 - error TS7016: Could not find a declaration file for module 'react-window'. '/Users/f692193/projects/figma-export-to-css-variables/node_modules/react-window/dist/index.cjs.js' implicitly has an 'any' type.