### PR TITLE
Control spacing of Split Layout

### DIFF
--- a/.changeset/cold-ravens-chew.md
+++ b/.changeset/cold-ravens-chew.md
@@ -1,0 +1,5 @@
+---
+"@jpmorganchase/uitk-lab": patch
+---
+
+Control spacing of Split Layout by adding the gap prop.

--- a/packages/lab/src/__tests__/__e2e__/layout/Split.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/layout/Split.cy.tsx
@@ -87,4 +87,14 @@ describe("GIVEN a Split", () => {
         .should("have.text", rightItem.join(""));
     });
   });
+
+  describe("WHEN passing the gap prop", () => {
+    it("THEN it should render with a new gap value", () => {
+      cy.mount(<DefaultSplitLayout gap={2} />);
+
+      cy.get(".uitkSplitLayout").should("have.css", "column-gap", "48px");
+
+      cy.get(".uitkSplitLayout").should("have.css", "row-gap", "48px");
+    });
+  });
 });

--- a/packages/lab/src/__tests__/__e2e__/layout/Split.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/layout/Split.cy.tsx
@@ -92,9 +92,9 @@ describe("GIVEN a Split", () => {
     it("THEN it should render with a new gap value", () => {
       cy.mount(<DefaultSplitLayout gap={2} />);
 
-      cy.get(".uitkSplitLayout").should("have.css", "column-gap", "48px");
+      cy.get(".uitkSplitLayout").should("have.css", "column-gap", "16px");
 
-      cy.get(".uitkSplitLayout").should("have.css", "row-gap", "48px");
+      cy.get(".uitkSplitLayout").should("have.css", "row-gap", "16px");
     });
   });
 });

--- a/packages/lab/src/layout/SplitLayout/SplitLayout.tsx
+++ b/packages/lab/src/layout/SplitLayout/SplitLayout.tsx
@@ -25,6 +25,10 @@ export interface SplitLayoutProps extends HTMLAttributes<HTMLDivElement> {
    */
   wrap?: FlexLayoutProps["wrap"];
   /**
+   * Controls the space between items.
+   */
+  gap?: FlexLayoutProps["gap"];
+  /**
    * Parent component to be rendered
    */
   leftSplitItem: ReactNode;
@@ -56,6 +60,7 @@ export const SplitLayout = forwardRef<HTMLDivElement, SplitLayoutProps>(
       separators,
       wrap = true,
       className,
+      gap,
       ...rest
     },
     ref
@@ -66,6 +71,7 @@ export const SplitLayout = forwardRef<HTMLDivElement, SplitLayoutProps>(
         direction="row"
         ref={ref}
         wrap={wrap}
+        gap={gap}
         className={cx(withBaseName(), className, {
           [withBaseName("separator")]: separatorAlignment,
           [withBaseName(`separator-${separatorAlignment}`)]:


### PR DESCRIPTION
Adding gap prop to SplitLayout to allow spacing to be controlled. Fixes #160.