### PR TITLE
refactor: remove duplicated `Status` declaration

### DIFF
--- a/packages/lab/src/content-status/ContentStatus.tsx
+++ b/packages/lab/src/content-status/ContentStatus.tsx
@@ -28,22 +28,14 @@ export type ContentStatusStatus =
   | "warning"
   | "info";
 
-export const Status = {
-  LOADING: "loading" as ContentStatusStatus,
-  ERROR: "error" as ContentStatusStatus,
-  SUCCESS: "success" as ContentStatusStatus,
-  WARNING: "warning" as ContentStatusStatus,
-  INFO: "info" as ContentStatusStatus,
+export const STATUS_TO_ICONS: { [key in Exclude<ContentStatusStatus, "loading">]: string } = {
+  "error": "error",
+  "success": "tick",
+  "warning": "warning",
+  "info": "info",
 };
 
-export const STATUS_TO_ICONS = {
-  [Status.ERROR]: "error",
-  [Status.SUCCESS]: "tick",
-  [Status.WARNING]: "warning",
-  [Status.INFO]: "info",
-};
-
-export type Status = keyof typeof Status;
+export type Status = ContentStatusStatus;
 
 export interface ContentStatusProps extends HTMLAttributes<HTMLDivElement> {
   CircularProgressProps?: Partial<CircularProgressProps>;
@@ -70,7 +62,7 @@ export const ContentStatus = forwardRef(function ContentStatus(
     disableAnnouncer,
     message,
     onActionClick,
-    status = Status.INFO,
+    status = "info",
     title,
     unit = "%",
     value,
@@ -97,7 +89,7 @@ export const ContentStatus = forwardRef(function ContentStatus(
       toBeAnnounced.push(message);
     }
     // Loading is announced by the spinner
-    if (status !== Status.LOADING) {
+    if (status !== "loading") {
       toBeAnnounced.push(status);
     }
     if (toBeAnnounced.length > 0) {

--- a/packages/lab/src/content-status/internal/renderStatusIndicator.tsx
+++ b/packages/lab/src/content-status/internal/renderStatusIndicator.tsx
@@ -61,7 +61,7 @@ const contentByType = new Map<
 ]);
 
 export function renderStatusIndicator({
-  status = Status.INFO,
+  status = "info",
   disableAnnouncer,
   unit,
   value,
@@ -72,7 +72,7 @@ export function renderStatusIndicator({
   id,
 }: Partial<ContentStatusProps>): ReactElement {
   const { icon: Icon, className } = contentByType.get(status)!;
-  if (status === Status.LOADING) {
+  if (status === "loading") {
     return value !== undefined
       ? getDeterminateLoadingComponent({
           unit,


### PR DESCRIPTION
Closes #197

Removed duplicated `Status` declaration, I've also improved the typing for `STATUS_TO_ICONS`