### PR TITLE
New storybook nav structure for docs; Checkbox, Switch docs

### DIFF
--- a/packages/core/stories/button.doc.stories.mdx
+++ b/packages/core/stories/button.doc.stories.mdx
@@ -1,12 +1,6 @@
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
 import { ComponentAnatomy } from "docs/components/ComponentAnatomy";
 import { Button, ToolkitProvider } from "@jpmorganchase/uitk-core";
-import {
-  DownloadIcon,
-  SearchIcon,
-  SendIcon,
-  SettingsSolidIcon,
-} from "@jpmorganchase/uitk-icons";
 import { withFlexGap } from "docs/decorators/withFlexGap";
 import { CustomStylingExample } from "./button.stories";
 import {
@@ -32,11 +26,9 @@ A Button executes an action when clicked. Button labels should use only one or t
 Button contains three variants `cta`, `primary` and `secondary`. If not specified, the default value is `primary`.
 
 <Canvas>
-  <Story name="Button Variants" decorators={[withFlexGap]}>
-    <Button variant="cta">CTA</Button>
-    <Button variant="primary">Primary</Button>
-    <Button variant="secondary">Secondary</Button>
-  </Story>
+  <Story id="core-button--cta" />
+  <Story id="core-button--primary" />
+  <Story id="core-button--secondary" />
 </Canvas>
 
 ## Button with icon and label
@@ -44,20 +36,7 @@ Button contains three variants `cta`, `primary` and `secondary`. If not specifie
 Icons can be put before or after text, or used alone.
 
 <Canvas>
-  <Story name="Button with icon and label" decorators={[withFlexGap]}>
-    <Button variant="cta">
-      Send <SendIcon size={12} />
-    </Button>
-    <Button variant="primary">
-      <SearchIcon size={12} /> Search
-    </Button>
-    <Button variant="secondary">
-      Setting <SettingsSolidIcon size={12} />
-    </Button>
-    <Button>
-      <DownloadIcon size={12} />
-    </Button>
-  </Story>
+  <Story id="core-button--with-icon-and-label" />
 </Canvas>
 
 ## Button as link, div etc
@@ -65,28 +44,11 @@ Icons can be put before or after text, or used alone.
 Sometimes a link must be styled as a button. The HTML must use the correct element, in order that browser built-in features function as expected.
 In this case, "Open link in new tab" should be available in the context menu. This is achieved with the `elementType` prop.
 
-<Canvas>
-  <Story name="Button as Link">
-    <Button
-      elementType="a"
-      href={window.location.href}
-      target="_blank"
-      aria-label="Button with HREF, opens in new window"
-    >
-      Link
-    </Button>
-  </Story>
-</Canvas>
-
 This is also useful where Button elements might otherwise be nested, a structure which would be flagged by accessibility tests as an error. An inner button can be
 rendered as a `div`.
 
 <Canvas>
-  <Story name="Button as Div">
-    <Button elementType="div" aria-label="Button as Div">
-      Div Button
-    </Button>
-  </Story>
+  <Story id="core-button--polymorphic-buttons" />
 </Canvas>
 
 TypeScript users, note that in the above examples, strict typing is still enforced, so if `elementType` is set to `a` then the Component will be be TypeChecked as
@@ -100,7 +62,9 @@ import { Button } from "@jpmorganchase/uitk-core";
 
 ## Props
 
-<ArgsTable of={Button} />
+<Story name="Props">
+  <ArgsTable of={Button} />
+</Story>
 
 ## HTML Anatomy of a Button
 
@@ -111,32 +75,34 @@ export const Link = ({ children, to, ...props }) => (
 );
 
 <Canvas>
-  <ComponentAnatomy>
-    <Button aria-label="Simple Button">Default</Button>
-  </ComponentAnatomy>
-  <br />
-  <ComponentAnatomy>
-    <Button elementType="div" aria-label="Button as Div" variant="secondary">
-      Secondary Div
-    </Button>
-  </ComponentAnatomy>
-  <br />
-  <ComponentAnatomy>
-    <Button variant="cta" aria-label="CTA with Icon">
-      CTA with Icon <SendIcon size={12} />
-    </Button>
-  </ComponentAnatomy>
-  <br />
-  <ComponentAnatomy>
-    <Button
-      elementType={Link}
-      to="/"
-      aria-label="Link as elementType"
-      role={null}
-    >
-      Custom Link
-    </Button>
-  </ComponentAnatomy>
+  <Story name="HTML Anatomy">
+    <ComponentAnatomy>
+      <Button aria-label="Simple Button">Default</Button>
+    </ComponentAnatomy>
+    <br />
+    <ComponentAnatomy>
+      <Button elementType="div" aria-label="Button as Div" variant="secondary">
+        Secondary Div
+      </Button>
+    </ComponentAnatomy>
+    <br />
+    <ComponentAnatomy>
+      <Button variant="cta" aria-label="CTA with Icon">
+        CTA with Icon <SendIcon size={12} />
+      </Button>
+    </ComponentAnatomy>
+    <br />
+    <ComponentAnatomy>
+      <Button
+        elementType={Link}
+        to="/"
+        aria-label="Link as elementType"
+        role={null}
+      >
+        Custom Link
+      </Button>
+    </ComponentAnatomy>
+  </Story>
 </Canvas>
 
 The Custom Link example above uses a simplified `Link` component defined as below. In reality, this might be A
@@ -154,11 +120,15 @@ export const Link = ({ children, to, ...props }) => (
 
 ## CSS Class
 
-<CSSClassTable of={Button} />
+<Story name="CSS Classes">
+  <CSSClassTable of={Button} />
+</Story>
 
 ## Characteristics Used
 
-<CharacteristicUsage of={Button} />
+<Story name="Characteristics">
+  <CharacteristicUsage of={Button} />
+</Story>
 
 ## --uitkButton CSS Custom Property API
 
@@ -169,7 +139,9 @@ The CSS custom properties below are consumed by Button, but not defined by Butto
 a custom class name to override button styling. They will always take precedence over default styles, whether from theme variable
 or declared locally. Again, see Theme documentation for guidance on when to use variables from the Custom Property API.
 
-<CSSVariableTable of={Button} />
+<Story name="Custom Property API">
+  <CSSVariableTable of={Button} />
+</Story>
 
 ## Customising Button styles - a fully worked through example
 
@@ -180,7 +152,7 @@ Below is an illustration of some of the buttons used in a new application. Compa
 - visual treatments not present on standard toolkit buttons - background gradients, border styling
 
 <Canvas>
-  <Story name="Custom Button Styling" decorators={[withFlexGap]}>
+  <Story name="Custom Styling" decorators={[withFlexGap]}>
     <CustomStylingExample density={"high"} />
   </Story>
 </Canvas>

--- a/packages/core/stories/button.stories.tsx
+++ b/packages/core/stories/button.stories.tsx
@@ -5,7 +5,13 @@ import {
   Density,
   ToolkitProvider,
 } from "@jpmorganchase/uitk-core";
-import { NotificationIcon, SearchIcon } from "@jpmorganchase/uitk-icons";
+import {
+  DownloadIcon,
+  SearchIcon,
+  SendIcon,
+  SettingsSolidIcon,
+  NotificationIcon,
+} from "@jpmorganchase/uitk-icons";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import "./Theme.stories.newapp-theme.css";
@@ -116,6 +122,25 @@ export const PolymorphicButtons: ComponentStory<typeof Button> = () => {
       <Button elementType="div">Div Button</Button>
       <Button elementType={Link} to="/">
         Custom Link
+      </Button>
+    </div>
+  );
+};
+
+export const WithIconAndLabel: ComponentStory<typeof Button> = () => {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+      <Button variant="cta">
+        Send <SendIcon size={12} />
+      </Button>
+      <Button variant="primary">
+        <SearchIcon size={12} /> Search
+      </Button>
+      <Button variant="secondary">
+        Setting <SettingsSolidIcon size={12} />
+      </Button>
+      <Button>
+        <DownloadIcon size={12} />
       </Button>
     </div>
   );

--- a/packages/core/stories/card.doc.stories.mdx
+++ b/packages/core/stories/card.doc.stories.mdx
@@ -26,19 +26,22 @@ import {
 
 A Card is a sheet of material that serves as an entry point to more detailed information. It is a convenient means of displaying content composed of different elements whose size or supported actions vary.
 
-## Card Component
-
-Card components have two levels of emphasis; medium (default) and high.
+## Default
 
 <Canvas>
-  <Story name="Card" decorators={[withFlexGap]}>
-    <Card>
-      <div>
-        <h1>This is Card</h1>
-        <span>Using Nested DOM Elements</span>
-      </div>
-    </Card>
-  </Story>
+  <Story id="core-card--default-card" />
+</Canvas>
+
+## Disabled
+
+<Canvas>
+  <Story id="core-card--disabled" />
+</Canvas>
+
+## Interactable
+
+<Canvas>
+  <Story id="core-card--interactable" />
 </Canvas>
 
 # API
@@ -49,29 +52,37 @@ import { Card } from "@jpmorganchase/uitk-core";
 
 ## Props
 
-<ArgsTable of={Card} />
+<Story name="Props">
+  <ArgsTable of={Card} />
+</Story>
 
 ## HTML Anatomy of a Card
 
 <Canvas>
-  <ComponentAnatomy>
-    <DefaultCard />
-  </ComponentAnatomy>
-  <ComponentAnatomy>
-    <Disabled />
-  </ComponentAnatomy>
-  <ComponentAnatomy>
-    <Interactable />
-  </ComponentAnatomy>
+  <Story name="HTML Anatomy">
+    <ComponentAnatomy>
+      <DefaultCard />
+    </ComponentAnatomy>
+    <ComponentAnatomy>
+      <Disabled />
+    </ComponentAnatomy>
+    <ComponentAnatomy>
+      <Interactable />
+    </ComponentAnatomy>
+  </Story>
 </Canvas>
 
 ## CSS Class
 
-<CSSClassTable of={Card} />
+<Story name="CSS Classes">
+  <CSSClassTable of={Card} />
+</Story>
 
 ## Characteristics Used
 
-<CharacteristicUsage of={Card} />
+<Story name="Characteristics">
+  <CharacteristicUsage of={Card} />
+</Story>
 
 ## --uitkCard CSS Custom Property API
 
@@ -82,7 +93,9 @@ The CSS custom properties below are consumed by Card, but not defined by Card. T
 a custom class name to override card styling. They will always take precedence over default styles, whether from theme variable
 or declared locally. Again, see Theme documentation for guidance on when to use variables from the Custom Property API.
 
-<CSSVariableTable of={Card} />
+<Story name="Custom Property API">
+  <CSSVariableTable of={Card} />
+</Story>
 
 ## Customising Card styles - a simple example
 
@@ -90,7 +103,7 @@ Because Card is such a simple component, custom styling is straightforward. In t
 tweak the look of a Card. The CSS variables above have been defined in the `newapp` theme (see Button example for fuller explanation).
 
 <Canvas>
-  <Story name="Custom Panel Styling" decorators={[withFlexGap]}>
+  <Story name="Custom Styling" decorators={[withFlexGap]}>
     <CustomStyling />
   </Story>
 </Canvas>

--- a/packages/core/stories/form-field.doc.stories.mdx
+++ b/packages/core/stories/form-field.doc.stories.mdx
@@ -1,12 +1,14 @@
 import { FormField, Input } from "@jpmorganchase/uitk-core";
 import { Meta, Canvas, ArgsTable } from "@storybook/addon-docs";
-import "docs/components/ComponentAnatomy.css";
+import { ComponentAnatomy } from "docs/components/ComponentAnatomy";
+import { CustomStyling } from "./form-field.stories";
+import { withFlexGap } from "docs/decorators/withFlexGap";
 import {
   CSSClassTable,
   CSSVariableTable,
   CharacteristicUsage,
 } from "css-variable-docgen-components";
-import { ComponentAnatomy } from "docs/components/ComponentAnatomy";
+import "docs/components/ComponentAnatomy.css";
 
 <Meta
   title="Documentation/Core/Form Field"
@@ -18,6 +20,70 @@ import { ComponentAnatomy } from "docs/components/ComponentAnatomy";
 
 # Form Field
 
+Form Field is a wrapper that provides an editable component with various states, a descriptive label, help text and optional or required flags. It’s ADA compliant, and is typically used in the context of a form.
+
+For demonstration purposes, all examples on this page include the Input component. Input, however, is not included in the Form Field package.
+
+## Default
+
+<Canvas>
+  <Story id="lab-form-field--default" />
+</Canvas>
+
+## High emphasis
+
+<Canvas>
+  <Story id="lab-form-field--high-emphasis" />
+</Canvas>
+
+## Low emphasis
+
+<Canvas>
+  <Story id="lab-form-field--low-emphasis" />
+</Canvas>
+
+## Disabled
+
+<Canvas>
+  <Story id="lab-form-field--disabled" />
+</Canvas>
+
+## Readonly
+
+<Canvas>
+  <Story id="lab-form-field--readonly" />
+</Canvas>
+
+## Helper Text
+
+<Canvas>
+  <Story id="lab-form-field--helper-text" />
+</Canvas>
+
+## Validation States
+
+<Canvas>
+  <Story id="lab-form-field--validation-states" />
+</Canvas>
+
+## Label alignments
+
+<Canvas>
+  <Story id="lab-form-field--label-alignments" />
+</Canvas>
+
+## Necessity
+
+<Canvas>
+  <Story id="lab-form-field--necessity" />
+</Canvas>
+
+## Status Indicator
+
+<Canvas>
+  <Story id="lab-form-field--status-indicator" />
+</Canvas>
+
 # API
 
 ```
@@ -26,26 +92,47 @@ import { FormField } from "@jpmorganchase/uitk-core";
 
 ## Props
 
-<ArgsTable of={FormField} />
+<Story name="Props">
+  <ArgsTable of={FormField} />
+</Story>
 
 ## HTML Anatomy of a Form Field
 
 <Canvas>
-  <ComponentAnatomy showControls={false}>
-    <FormField helperText="Sample helper text" label="Default Form Field label">
-      <Input defaultValue="Value" />
-    </FormField>
-  </ComponentAnatomy>
+  <Story name="HTML Anatomy">
+    <ComponentAnatomy showControls={false}>
+      <FormField
+        helperText="Sample helper text"
+        label="Default Form Field label"
+      >
+        <Input defaultValue="Value" />
+      </FormField>
+    </ComponentAnatomy>
+  </Story>
 </Canvas>
 
 ## CSS Class
 
-<CSSClassTable of={FormField} />
+<Story name="CSS Classes">
+  <CSSClassTable of={FormField} />
+</Story>
 
 ## Characteristics Used
 
-<CharacteristicUsage of={FormField} />
+<Story name="Characteristics">
+  <CharacteristicUsage of={FormField} />
+</Story>
 
 ## --uitkFormField CSS Custom Property API
 
-<CSSVariableTable of={FormField} />
+<Story name="Custom Property API">
+  <CSSVariableTable of={FormField} />
+</Story>
+
+## Customising FormField styles
+
+<Canvas>
+  <Story name="Custom Styling" decorators={[withFlexGap]}>
+    <CustomStyling />
+  </Story>
+</Canvas>

--- a/packages/core/stories/input.doc.stories.mdx
+++ b/packages/core/stories/input.doc.stories.mdx
@@ -30,9 +30,7 @@ The Input component provides an editable field in which users can enter arbitrar
 ## Basic Input Component
 
 <Canvas>
-  <Story name="Basic Input" decorators={[withFlexGap]}>
-    <Input defaultValue={"Value"} style={{ width: "292px" }} />
-  </Story>
+  <Story id="lab-input--feature-input" />
 </Canvas>
 
 ## Read Only Input
@@ -40,13 +38,7 @@ The Input component provides an editable field in which users can enter arbitrar
 Read only mode switched on by providing the `readOnly` prop.
 
 <Canvas>
-  <Story name="Read Only" decorators={[withFlexGap]}>
-    <Input
-      defaultValue={"Read Only Input"}
-      readOnly
-      style={{ width: "292px" }}
-    />
-  </Story>
+  <Story id="lab-input--read-only" />
 </Canvas>
 
 ## Input with spellcheck
@@ -54,13 +46,7 @@ Read only mode switched on by providing the `readOnly` prop.
 Automatic spellchecking can be turned on by using `inputProps`.
 
 <Canvas>
-  <Story name="Input with spellcheck" decorators={[withFlexGap]}>
-    <Input
-      defaultValue="This is a comment. It contains several sentences, with words spelt correctly or incorectly. Click to see Spellcheck take effect."
-      style={{ width: "292px" }}
-      inputProps={{ spellCheck: true }}
-    />
-  </Story>
+  <Story id="lab-input--spellcheck" />
 </Canvas>
 
 ## Input with adornments
@@ -68,32 +54,7 @@ Automatic spellchecking can be turned on by using `inputProps`.
 Icons and text can be used as adornments at the start or end of the component.
 
 <Canvas>
-  <Story name="Input with adornments" decorators={[withFlexGap]}>
-    <div>
-      <Input
-        defaultValue="Prefix: Icon"
-        startAdornment={
-          <StaticInputAdornment>
-            <CallIcon />
-          </StaticInputAdornment>
-        }
-      />
-      <div style={{ height: "15px" }} />
-      <Input
-        defaultValue="Suffix: Icon"
-        endAdornment={
-          <StaticInputAdornment>
-            <CalendarIcon size="small" />
-          </StaticInputAdornment>
-        }
-      />
-      <div style={{ height: "15px" }} />
-      <Input
-        defaultValue="Suffix: Text"
-        endAdornment={<StaticInputAdornment>KG</StaticInputAdornment>}
-      />
-    </div>
-  </Story>
+  <Story id="lab-input--adornments" />
 </Canvas>
 
 ## Used in FormField
@@ -101,11 +62,7 @@ Icons and text can be used as adornments at the start or end of the component.
 Input is a component that would commonly be nested inside a FormField.
 
 <Canvas>
-  <Story name="Used in FormField" decorators={[withFlexGap]}>
-    <FormField label="ADA compliant label" style={{ width: 292 }}>
-      <Input defaultValue="Value" />
-    </FormField>
-  </Story>
+  <Story id="lab-input--with-form-field" />
 </Canvas>
 
 # API
@@ -116,46 +73,54 @@ import { Input } from "@jpmorganchase/uitk-core";
 
 ## Props
 
-<ArgsTable of={Input} />
+<Story name="Props">
+  <ArgsTable of={Input} />
+</Story>
 
 ## HTML Anatomy of Input component
 
 <Canvas>
-  <ComponentAnatomy>
-    <Input defaultValue={"Default"} style={{ width: "292px" }} />
-  </ComponentAnatomy>
-  <ComponentAnatomy>
-    <Input
-      defaultValue={"Read Only Input"}
-      readOnly
-      style={{ width: "292px" }}
-    />
-  </ComponentAnatomy>
-  <ComponentAnatomy>
-    <Input
-      defaultValue="Prefix: Icon"
-      startAdornment={
-        <StaticInputAdornment>
-          <CallIcon />
-        </StaticInputAdornment>
-      }
-    />
-  </ComponentAnatomy>
-  <ComponentAnatomy>
-    <Input
-      defaultValue="Suffix: Text"
-      endAdornment={<StaticInputAdornment>KG</StaticInputAdornment>}
-    />
-  </ComponentAnatomy>
+  <Story name="HTML Anatomy">
+    <ComponentAnatomy>
+      <Input defaultValue={"Default"} style={{ width: "292px" }} />
+    </ComponentAnatomy>
+    <ComponentAnatomy>
+      <Input
+        defaultValue={"Read Only Input"}
+        readOnly
+        style={{ width: "292px" }}
+      />
+    </ComponentAnatomy>
+    <ComponentAnatomy>
+      <Input
+        defaultValue="Prefix: Icon"
+        startAdornment={
+          <StaticInputAdornment>
+            <CallIcon />
+          </StaticInputAdornment>
+        }
+      />
+    </ComponentAnatomy>
+    <ComponentAnatomy>
+      <Input
+        defaultValue="Suffix: Text"
+        endAdornment={<StaticInputAdornment>KG</StaticInputAdornment>}
+      />
+    </ComponentAnatomy>
+  </Story>
 </Canvas>
 
 ## CSS Class
 
-<CSSClassTable of={Input} />
+<Story name="CSS Classes">
+  <CSSClassTable of={Input} />
+</Story>
 
 ## Characteristics Used
 
-<CharacteristicUsage of={Input} />
+<Story name="Characteristics">
+  <CharacteristicUsage of={Input} />
+</Story>
 
 ## --uitkInput CSS Custom Property API
 
@@ -166,12 +131,14 @@ The CSS custom properties below are consumed by Input, but not defined by Input.
 a custom class name to override input styling. They will always take precedence over default styles, whether from theme variable
 or declared locally. Again, see Theme documentation for guidance on when to use variables from the Custom Property API.
 
-<CSSVariableTable of={Input} />
+<Story name="Custom Property API">
+  <CSSVariableTable of={Input} />
+</Story>
 
 ## Customising Input styles
 
 <Canvas>
-  <Story name="Custom Input Styling" decorators={[withFlexGap]}>
+  <Story name="Custom Styling" decorators={[withFlexGap]}>
     <CustomStyling />
   </Story>
 </Canvas>

--- a/packages/core/stories/panel.doc.stories.mdx
+++ b/packages/core/stories/panel.doc.stories.mdx
@@ -27,12 +27,8 @@ A panel is a way to organize content areas in an application (both web and deskt
 Panel components have two levels of emphasis; medium (default) and high.
 
 <Canvas>
-  <Story name="Panels" decorators={[withFlexGap]}>
-    <Panel>This is a panel around some text.</Panel>
-    <Panel className="uitkEmphasisHigh">
-      This is a panel around some text with high emphasis.
-    </Panel>
-  </Story>
+  <Story id="core-panel--medium-emphasis" />
+  <Story id="core-panel--high-emphasis" />
 </Canvas>
 
 # API
@@ -43,28 +39,36 @@ import { Panel } from "@jpmorganchase/uitk-core";
 
 ## Props
 
-<ArgsTable of={Panel} />
+<Story name="Props">
+  <ArgsTable of={Panel} />
+</Story>
 
 ## HTML Anatomy of a Panel
 
 <Canvas>
-  <ComponentAnatomy>
-    <Panel aria-label="Default Panel">Default</Panel>
-  </ComponentAnatomy>
-  <ComponentAnatomy>
-    <Panel aria-label="Panel with high emphasis" className="uitkEmphasisHigh">
-      High emphasis
-    </Panel>
-  </ComponentAnatomy>
+  <Story name="HTML Anatomy">
+    <ComponentAnatomy>
+      <Panel aria-label="Default Panel">Default</Panel>
+    </ComponentAnatomy>
+    <ComponentAnatomy>
+      <Panel aria-label="Panel with high emphasis" className="uitkEmphasisHigh">
+        High emphasis
+      </Panel>
+    </ComponentAnatomy>
+  </Story>
 </Canvas>
 
 ## CSS Class
 
-<CSSClassTable of={Panel} />
+<Story name="CSS Classes">
+  <CSSClassTable of={Panel} />
+</Story>
 
 ## Characteristics Used
 
-<CharacteristicUsage of={Panel} />
+<Story name="Characteristics">
+  <CharacteristicUsage of={Panel} />
+</Story>
 
 ## --uitkPanel CSS Custom Property API
 
@@ -75,7 +79,9 @@ The CSS custom properties below are consumed by Panel, but not defined by Panel.
 a custom class name to override card styling. They will always take precedence over default styles, whether from theme variable
 or declared locally. Again, see Theme documentation for guidance on when to use variables from the Custom Property API.
 
-<CSSVariableTable of={Panel} />
+<Story name="Custom Property API">
+  <CSSVariableTable of={Panel} />
+</Story>
 
 ## Customising Panel styles - a simple example
 
@@ -83,7 +89,7 @@ Because Panel is such a simple component, custom styling is straightforward. In 
 tweak the look of a Panel. The CSS variables above have been defined in the `newapp` theme (see Button example for fuller explanation).
 
 <Canvas>
-  <Story name="Custom Panel Styling" decorators={[withFlexGap]}>
+  <Story name="Custom Styling" decorators={[withFlexGap]}>
     <CustomStyling />
   </Story>
 </Canvas>

--- a/packages/core/stories/pill.doc.stories.mdx
+++ b/packages/core/stories/pill.doc.stories.mdx
@@ -90,9 +90,7 @@ page, the ‘role’ prop must be changed from ‘button’ (the default attribu
   [Button](/?path=/docs/toolkit-2-0-button) instead.
 
 <Canvas>
-  <Story name="Basic Pill">
-    <Pill label="Basic Pill" />
-  </Story>
+  <Story id="lab-pill--feature-pill" />
 </Canvas>
 
 ## Closable
@@ -116,9 +114,7 @@ that adds a new Pill.
   visible.
 
 <Canvas>
-  <Story name="Closable">
-    <Pill label="Closable Pill" variant="closable" />
-  </Story>
+  <Story id="lab-pill--closable-pill" />
 </Canvas>
 
 ## Selectable
@@ -144,9 +140,7 @@ ideal selection mechanism for a compact layout or user interface.
   more appropriate.
 
 <Canvas>
-  <Story name="Selectable">
-    <Pill label="Selectable Pill" variant="selectable" />
-  </Story>
+  <Story id="lab-pill--selectable-pill" />
 </Canvas>
 
 ## Maximum Width
@@ -160,13 +154,7 @@ By default, the Tooltip is positioned above the Pill unless screen real estate
 does not allow—in that case it’s auto-repositioned.
 
 <Canvas>
-  <Story name="MaximumWidth">
-    <Pill
-      label="Extra extra long Pill label example."
-      style={{ marginRight: 24 }}
-    />
-    <Pill label="FX" />
-  </Story>
+  <Story id="lab-pill--max-width-pill" />
 </Canvas>
 
 ## Icon Descriptors
@@ -175,9 +163,7 @@ Icons can be displayed on the left of a Basic or Closable Pill label to visually
 reinforce the theme or grouping of that Pill, and for quick recognition.
 
 <Canvas>
-  <Story name="Icon Descriptors">
-    <Pill icon={<UserBadgeIcon />} label="Pill with Icon" />
-  </Story>
+  <Story id="lab-pill--icon-pill" />
 </Canvas>
 
 ## Disabled
@@ -186,9 +172,7 @@ A Pill can be set to a disabled state, with no resultant action when the user
 interacts with it.
 
 <Canvas>
-  <Story name="Disabled">
-    <Pill label="Disabled Pill" disabled variant="closable" />
-  </Story>
+  <Story id="lab-pill--disabled-pill" />
 </Canvas>
 
 ## Controlled
@@ -231,16 +215,20 @@ import { Pill } from "@jpmorganchase/uitk-core";
 
 When `variant` is `'basic'` or '`closable`'
 
-<ArgsTable of={Pill} />
+<Story name="Props">
+  <ArgsTable of={Pill} />
+</Story>
 
 When `variant` is `'selectable'`
 
-<ArgsTable of={SelectablePill} />
+<Story name="Selectable Props">
+  <ArgsTable of={SelectablePill} />
+</Story>
 
 ## HTML Anatomy of Pill component
 
 <Canvas>
-  <Story name="Pill Anatomy">
+  <Story name="HTML Anatomy">
     <ComponentAnatomy>
       <Pill label="Basic Pill" />
     </ComponentAnatomy>
@@ -258,7 +246,9 @@ When `variant` is `'selectable'`
 
 ## CSS Class
 
-<CSSClassTable of={Pill} />
+<Story name="CSS Classes">
+  <CSSClassTable of={Pill} />
+</Story>
 
 ## Characteristics Used
 
@@ -273,12 +263,14 @@ The CSS custom properties below are consumed by Pill, but not defined by Pill. T
 a custom class name to override Pill styling. They will always take precedence over default styles, whether from theme variable
 or declared locally. Again, see Theme documentation for guidance on when to use variables from the Custom Property API.
 
-<CSSVariableTable of={Pill} />
+<Story name="Custom Property API">
+  <CSSVariableTable of={Pill} />
+</Story>
 
 ## Customising Pill styles
 
 <Canvas>
-  <Story name="Custom Pill Styling" decorators={[withFlexGap]}>
+  <Story name="Custom Styling" decorators={[withFlexGap]}>
     <CustomStyling />
   </Story>
 </Canvas>

--- a/packages/core/stories/radio-button.doc.stories.mdx
+++ b/packages/core/stories/radio-button.doc.stories.mdx
@@ -31,34 +31,13 @@ Radio groups allow selection of one or more values from a given set of choices. 
 - If there are more than 5 choices, use a Multiselect control instead.
 
 <Canvas>
-  <Story name="Vertical Group" decorators={[withFlexGap]}>
-    <RadioButtonGroup
-      aria-label="Uncontrolled Example"
-      defaultValue="forward"
-      legend={"Legend"}
-      name={"Name"}
-    >
-      <RadioButton key="spot" label="Spot" value="spot" />
-      <RadioButton key="forward" label="Forward" value="forward" />
-      <RadioButton
-        disabled
-        key="option"
-        label="Option (disabled)"
-        value="option"
-      />
-    </RadioButtonGroup>
-  </Story>
+  <Story id="lab-radio-button--uncontrolled-radio-button-group" />
 </Canvas>
 
 ## Row Group
 
 <Canvas>
-  <Story name="Row Group" decorators={[withFlexGap]}>
-    <RadioButtonGroup legend={"Legend"} name={"Name"} row>
-      <RadioButton key="spot" label="Spot" value="spot" />
-      <RadioButton key="forward" label="Forward" value="forward" />
-    </RadioButtonGroup>
-  </Story>
+  <Story id="lab-radio-button--horizontal-radio-button-group" />
 </Canvas>
 
 ## Controlled
@@ -91,23 +70,31 @@ import { RadioButton, RadioButtonGroup } from "@jpmorganchase/uitk-core";
 
 ## Props
 
-<ArgsTable of={RadioButton} />
+<Story name="Props">
+  <ArgsTable of={RadioButton} />
+</Story>
 
 ## HTML Anatomy of RadioButton component
 
 <Canvas>
-  <ComponentAnatomy>
-    <RadioButton key="spot" label="Spot" value="spot" />
-  </ComponentAnatomy>
+  <Story name="HTML Anatomy">
+    <ComponentAnatomy>
+      <RadioButton key="spot" label="Spot" value="spot" />
+    </ComponentAnatomy>
+  </Story>
 </Canvas>
 
 ## CSS Class
 
-<CSSClassTable of={RadioButton} />
+<Story name="CSS Classes">
+  <CSSClassTable of={RadioButton} />
+</Story>
 
 ## Characteristics Used
 
-<CharacteristicUsage of={RadioButton} />
+<Story name="Characteristics">
+  <CharacteristicUsage of={RadioButton} />
+</Story>
 
 ## --uitkRadioButton CSS Custom Property API
 
@@ -118,10 +105,12 @@ The CSS custom properties below are consumed by RadioButton, but not defined by 
 a custom class name to override RadioButton styling. They will always take precedence over default styles, whether from theme variable
 or declared locally. Again, see Theme documentation for guidance on when to use variables from the Custom Property API.
 
-<CSSVariableTable of={RadioButton} />
+<Story name="Custom Property API">
+  <CSSVariableTable of={RadioButton} />
+</Story>
 
 ## Customising RadioButton styles
 
 <Canvas>
-  <Story name="Custom RadioButton Styling" decorators={[withFlexGap]}></Story>
+  <Story name="Custom Styling" decorators={[withFlexGap]}></Story>
 </Canvas>

--- a/packages/core/stories/switch.doc.stories.mdx
+++ b/packages/core/stories/switch.doc.stories.mdx
@@ -6,6 +6,7 @@ import {
   CharacteristicUsage,
   CSSClassTable,
   CSSVariableTable,
+  CharacteristicUsage,
 } from "css-variable-docgen-components";
 import { CustomStyling } from "./switch.stories";
 
@@ -26,9 +27,7 @@ A Switch is a control that behaves like a checkbox but should only be used if th
 By default the Switch will handle the checkbox state automatically. The value can be set using the defaultChecked prop. The checked prop should only be used if you want a controlled Switch that requires some logic for validating value. The `onChange` event can be used to read the value using the second parameter.
 
 <Canvas>
-  <Story name="Basic Switch" decorators={[withFlexGap]}>
-    <Switch label="Basic Switch" />
-  </Story>
+  <Story id="lab-switch--feature-switch" />
 </Canvas>
 
 ## Checked
@@ -36,9 +35,7 @@ By default the Switch will handle the checkbox state automatically. The value ca
 Using the prop `defaultChecked` a Switch can be set to checked but still be used as an uncontrolled component.
 
 <Canvas>
-  <Story name="Checked" decorators={[withFlexGap]}>
-    <Switch defaultChecked={true} label="Checked" />
-  </Story>
+  <Story id="lab-switch--checked" />
 </Canvas>
 
 ## Controlled
@@ -46,9 +43,7 @@ Using the prop `defaultChecked` a Switch can be set to checked but still be used
 A controlled Switch will rely on the application to manually set the value through the checked prop. The onChange event should be used to read the value and decide what the next value should be. This value is updated by changing the checked prop.
 
 <Canvas>
-  <Story name="Controlled" decorators={[withFlexGap]}>
-    <Switch checked={true} onChange={null} label="Controlled" />
-  </Story>
+  <Story id="lab-switch--controlled" />
 </Canvas>
 
 ## Disabled
@@ -56,9 +51,7 @@ A controlled Switch will rely on the application to manually set the value throu
 Disabled Switches can be either true or false but cannot be changed. Disabled Switches have a 0.4 opacity applied to indicate the restricted state.
 
 <Canvas>
-  <Story name="Disabled" decorators={[withFlexGap]}>
-    <Switch disabled label="Disabled" />
-  </Story>
+  <Story id="lab-switch--disabled" />
 </Canvas>
 
 # API
@@ -69,12 +62,14 @@ import { Switch } from "@jpmorganchase/uitk-core";
 
 ## Props
 
-<ArgsTable of={Switch} />
+<Story name="Props">
+  <ArgsTable of={Switch} />
+</Story>
 
 ## HTML Anatomy of Switch component
 
 <Canvas>
-  <Story name="Switch Anatomy">
+  <Story name="HTML Anatomy">
     <ComponentAnatomy>
       <Switch />
     </ComponentAnatomy>
@@ -89,11 +84,15 @@ import { Switch } from "@jpmorganchase/uitk-core";
 
 ## CSS Class
 
-<CSSClassTable of={Switch} />
+<Story name="CSS Classes">
+  <CSSClassTable of={Switch} />
+</Story>
 
 ## Characteristics Used
 
-<CharacteristicUsage of={Switch} />
+<Story name="Characteristics">
+  <CharacteristicUsage of={Switch} />
+</Story>
 
 ## --uitkSwitch CSS Custom Property API
 
@@ -104,12 +103,14 @@ The CSS custom properties below are consumed by Switch, but not defined by Switc
 a custom class name to override Switch styling. They will always take precedence over default styles, whether from theme variable
 or declared locally. Again, see Theme documentation for guidance on when to use variables from the Custom Property API.
 
-<CSSVariableTable of={Switch} />
+<Story name="Custom Property API">
+  <CSSVariableTable of={Switch} />
+</Story>
 
 ## Customising Switch styles
 
 <Canvas>
-  <Story name="Custom Switch Styling" decorators={[withFlexGap]}>
+  <Story name="Custom Styling" decorators={[withFlexGap]}>
     <CustomStyling />
   </Story>
 </Canvas>

--- a/packages/lab/stories/checkbox.doc.stories.mdx
+++ b/packages/lab/stories/checkbox.doc.stories.mdx
@@ -1,0 +1,122 @@
+import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
+import { ComponentAnatomy } from "docs/components/ComponentAnatomy";
+import { ToolkitProvider } from "@jpmorganchase/uitk-core";
+import { Checkbox } from "@jpmorganchase/uitk-lab";
+import { withFlexGap } from "docs/decorators/withFlexGap";
+import {
+  CSSClassTable,
+  CSSVariableTable,
+  CharacteristicUsage,
+} from "css-variable-docgen-components";
+import { CustomStyling } from "./checkbox.stories";
+
+<Meta
+  title="Documentation/Lab/Checkbox"
+  component={Checkbox}
+  parameters={{
+    viewMode: "docs",
+  }}
+/>
+
+# Checkbox
+
+A Checkbox allows the user to turn a specific value on or off. The value can be an independent value or a selection of one or more values from a given set of choices (structured as a Checkbox Group).
+
+## Default
+
+Standalone checkboxes independently select a value and typically appear on preference panes. When the user needs to pick from related choices, use a Checkbox Group.
+
+<Canvas>
+  <Story id="lab-checkbox--default" />
+</Canvas>
+
+## Disabled
+
+Disabled checkboxes are shown with .4 opacity and are not able to be focused and will show a 'not-allowed' cursor.
+
+<Canvas>
+  <Story id="lab-checkbox--disabled" />
+</Canvas>
+
+## Controlled
+
+Controlled checkboxes require events to trigger the state change. The application must track state and update checkbox props manually. Useful for when logic or validation needs to be applied or a request should happen when updating a form.
+
+<Canvas>
+  <Story id="lab-checkbox--controlled-group" />
+</Canvas>
+
+## Uncontrolled
+
+<Canvas>
+  <Story id="lab-checkbox--uncontrolled-group" />
+</Canvas>
+
+## Horizontal Row Group
+
+The checkbox group layout can be set to horizontal simply by adding the prop 'row' to the CheckboxGroup component.
+
+<Canvas>
+  <Story id="lab-checkbox--horizontal-group" />
+</Canvas>
+
+# API
+
+```
+import { Checkbox } from "@jpmorganchase/uitk-lab";
+```
+
+## Props
+
+<Story name="Props">
+  <ArgsTable of={Checkbox} />
+</Story>
+
+## HTML Anatomy of Checkbox component
+
+<Canvas>
+  <Story name="HTML Anatomy">
+    <ComponentAnatomy showLegend>
+      <Checkbox />
+    </ComponentAnatomy>
+    <ComponentAnatomy showLegend>
+      <Checkbox defaultChecked={true} label="Checked" />
+    </ComponentAnatomy>
+    <ComponentAnatomy showLegend>
+      <Checkbox disabled label="Disabled" />
+    </ComponentAnatomy>
+  </Story>
+</Canvas>
+
+## CSS Class
+
+<Story name="CSS Classes">
+  <CSSClassTable of={Checkbox} />
+</Story>
+
+## Characteristics Used
+
+<Story name="Characteristics">
+  <CharacteristicUsage of={Checkbox} />
+</Story>
+
+## --uitkCheckbox CSS Custom Property API
+
+The default styling values for most Checkbox attributes are provided by the theme variables. A smaller number of attributes
+use hard-coded values local to Checkbox. Both of these can be overridden, see Theme documentation for detailed usage guidance.
+
+The CSS custom properties below are consumed by Checkbox, but not defined by Checkbox. They can be defined via a container or
+a custom class name to override Checkbox styling. They will always take precedence over default styles, whether from theme variable
+or declared locally. Again, see Theme documentation for guidance on when to use variables from the Custom Property API.
+
+<Story name="Custom Property API">
+  <CSSVariableTable of={Checkbox} />
+</Story>
+
+## Customising Checkbox styles
+
+<Canvas>
+  <Story name="Custom Styling" decorators={[withFlexGap]}>
+    <CustomStyling />
+  </Story>
+</Canvas>


### PR DESCRIPTION
New nav structure makes it easier to find and ensure that the following is included in all complete component docs:

- API
- Props Table
- HTML Anatomy
- CSS Class
- Characteristics Used
- Custom Property API
- Customising styles

Also changes how stories are referred to by their id rather than re-writing them within the docs. Allows us to also ensure we give supporting documentation to all the existing stories by directly referencing them. I think we should not have each of these listed in the sidebar again, but we should somehow have an 'Examples' anchor in the sidebar just before the first example