### PR TITLE
Standardize backwards compat classes and QA

### DIFF
--- a/.changeset/witty-donkeys-deliver.md
+++ b/.changeset/witty-donkeys-deliver.md
@@ -1,0 +1,6 @@
+---
+"@jpmorganchase/uitk-core": patch
+"@jpmorganchase/uitk-lab": patch
+---
+
+Standardize backwards compat classes and QA

--- a/packages/core/src/card/Card.css
+++ b/packages/core/src/card/Card.css
@@ -22,13 +22,9 @@
 .uitkCard-content {
   font-size: var(--uitkCard-content-fontSize, var(--uitk-text-fontSize));
   letter-spacing: var(--uitkCard-content-letterSpacing, normal);
-  line-height: var(--uitkCard-content-lineHeight, var(--uitk-text-lineHeight));
+  line-height: var(--uitkCard-content-lineHeight, var(--uitk-typography-lineHeight));
   min-height: var(--uitkCard-content-minHeight, var(--uitk-text-minHeight));
   padding: var(--uitkCard-padding, calc(var(--uitk-size-unit) * 3));
-}
-
-.backwardsCompat.uitkCard {
-  --uitkCard-content-lineHeight: 1.3;
 }
 
 /* Styles applied if `disabled={true}` */

--- a/packages/core/src/card/Card.css
+++ b/packages/core/src/card/Card.css
@@ -22,7 +22,6 @@
 .uitkCard-content {
   font-size: var(--uitkCard-content-fontSize, var(--uitk-text-fontSize));
   letter-spacing: var(--uitkCard-content-letterSpacing, normal);
-  line-height: var(--uitkCard-content-lineHeight, var(--uitk-typography-lineHeight));
   min-height: var(--uitkCard-content-minHeight, var(--uitk-text-minHeight));
   padding: var(--uitkCard-padding, calc(var(--uitk-size-unit) * 3));
 }
@@ -67,4 +66,9 @@ a:focus .uitkCard-interactable,
   outline-width: var(--uitk-focused-outlineWidth);
   outline-color: var(--uitk-focused-outlineColor);
   outline-offset: var(--uitk-focused-outlineOffset);
+}
+
+/* TK1 backwards compat styling */
+.backwardsCompat.uitkCard .uitkCard-content {
+  line-height: var(--uitk-typography-lineHeight);
 }

--- a/packages/core/stories/card.qa.stories.css
+++ b/packages/core/stories/card.qa.stories.css
@@ -1,10 +1,13 @@
 .uitkCardQA {
   --uitkDocGrid-width: 600px;
-  --uitkDocGrid-height: 616px;
   --uitkDocGrid-gap: 8px;
 
   --uitkCard-content-line-height: 1.3;
   --uitkCard-content-h1-line-height: 1.3;
+}
+
+.uitkCardQA .backwardsCompat {
+  --uitkDocGrid-height: 616px;
 }
 
 .uitkCardQA.uitkQAContainer {

--- a/packages/core/stories/card.qa.stories.tsx
+++ b/packages/core/stories/card.qa.stories.tsx
@@ -11,7 +11,7 @@ export default {
 export const AllExamplesGrid: ComponentStory<typeof Card> = () => {
   return (
     <AllRenderer className="uitkCardQA">
-      <Card className="backwardsCompat">
+      <Card>
         <div>
           <h1 style={{ margin: 0 }}>Card with density</h1>
           <span>Content</span>

--- a/packages/core/stories/card.qa.stories.tsx
+++ b/packages/core/stories/card.qa.stories.tsx
@@ -1,4 +1,5 @@
 import { Card } from "@jpmorganchase/uitk-core";
+import { H1, Text } from "@jpmorganchase/uitk-lab";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { AllRenderer, QAContainer } from "docs/components";
 import "./card.qa.stories.css";
@@ -8,14 +9,13 @@ export default {
   component: Card,
 } as ComponentMeta<typeof Card>;
 
-export const AllExamplesGrid: ComponentStory<typeof Card> = () => {
+export const AllExamplesGrid: ComponentStory<typeof Card> = (props) => {
+  const { className } = props;
   return (
     <AllRenderer className="uitkCardQA">
-      <Card>
-        <div>
-          <h1 style={{ margin: 0 }}>Card with density</h1>
-          <span>Content</span>
-        </div>
+      <Card className={className}>
+        <H1>Card with density</H1>
+        <Text>Content</Text>
       </Card>
     </AllRenderer>
   );
@@ -23,6 +23,19 @@ export const AllExamplesGrid: ComponentStory<typeof Card> = () => {
 
 AllExamplesGrid.parameters = {
   chromatic: { disableSnapshot: false },
+};
+
+export const BackwardsCompatGrid: ComponentStory<typeof Card> = () => {
+  return (
+    <AllRenderer className="uitkCardQA">
+      <Card className={"backwardsCompat"}>
+        <div>
+          <h1 style={{ margin: 0 }}>Card with density</h1>
+          <span>Content</span>
+        </div>
+      </Card>
+    </AllRenderer>
+  );
 };
 
 export const CompareWithOriginalToolkit: ComponentStory<typeof Card> = () => {
@@ -33,7 +46,7 @@ export const CompareWithOriginalToolkit: ComponentStory<typeof Card> = () => {
       className="uitkCardQA"
       imgSrc="/visual-regression-screenshots/Card-vr-snapshot.png"
     >
-      <AllExamplesGrid />
+      <BackwardsCompatGrid />
     </QAContainer>
   );
 };

--- a/packages/lab/src/checkbox/CheckboxIcon.css
+++ b/packages/lab/src/checkbox/CheckboxIcon.css
@@ -91,28 +91,28 @@
 }
 
 /* Backwards compat styling for TK1 */
-.backwardsCompat .uitk-light .uitkCheckbox:not(.uitkCheckbox-disabled):hover .uitkCheckboxIcon,
-.backwardsCompat .uitk-light .uitkCheckboxIcon:not(.uitkCheckboxIcon-disabled):hover {
-  stroke: rgb(46, 132, 198); /* blue-400 */
+.uitk-light .uitkCheckbox.backwardsCompat:not(.uitkCheckbox-disabled):hover .uitkCheckboxIcon,
+.uitk-light .uitkCheckbox.backwardsCompat .uitkCheckboxIcon:not(.uitkCheckboxIcon-disabled):hover {
+  stroke: var(--uitk-color-blue-400);
 }
 
-.backwardsCompat .uitk-light .uitkCheckboxIcon-checked {
-  fill: rgb(38, 112, 169); /* blue-500 */
+.uitk-light .uitkCheckbox.backwardsCompat .uitkCheckboxIcon-checked {
+  fill: var(--uitk-color-blue-500);
 }
 
-.backwardsCompat .uitk-light .uitkCheckboxIcon-checked.uitkCheckboxIcon-disabled {
-  fill: rgba(38, 112, 169, 0.7); /* blue-500 */
+.uitk-light .uitkCheckbox.backwardsCompat .uitkCheckboxIcon-checked.uitkCheckboxIcon-disabled {
+  fill: var(--uitk-color-blue-500);
 }
 
-.backwardsCompat .uitk-dark .uitkCheckbox:not(.uitkCheckbox-disabled):hover .uitkCheckboxIcon,
-.backwardsCompat .uitk-dark .uitkCheckboxIcon:not(.uitkCheckboxIcon-disabled):hover {
-  stroke: rgb(51, 141, 205); /* blue-300 */
+.uitk-dark .uitkCheckbox.backwardsCompat:not(.uitkCheckbox-disabled):hover .uitkCheckboxIcon,
+.uitk-dark .uitkCheckbox.backwardsCompat .uitkCheckboxIcon:not(.uitkCheckboxIcon-disabled):hover {
+  stroke: var(--uitk-color-blue-300);
 }
 
-.backwardsCompat .uitk-dark .uitkCheckboxIcon-checked {
-  fill: rgb(46, 132, 198); /* blue-400 */
+.uitk-dark .uitkCheckbox.backwardsCompat .uitkCheckboxIcon-checked {
+  fill: var(--uitk-color-blue-400);
 }
 
-.backwardsCompat .uitk-dark .uitkCheckboxIcon-checked.uitkCheckboxIcon-disabled {
-  fill: rgba(46, 132, 198, 0.7); /* blue-400 */
+.uitk-dark .uitkCheckbox.backwardsCompat .uitkCheckboxIcon-checked.uitkCheckboxIcon-disabled {
+  fill: var(--uitk-color-blue-400);
 }

--- a/packages/lab/src/dropdown/DropdownButton.css
+++ b/packages/lab/src/dropdown/DropdownButton.css
@@ -44,6 +44,6 @@
 }
 
 /* Backwards compat styling to match TK1 */
-.backwardsCompat .uitkDropdownButton {
+.backwardsCompat.uitkDropdown .uitkDropdownButton {
   letter-spacing: normal;
 }

--- a/packages/lab/src/metric/Metric.css
+++ b/packages/lab/src/metric/Metric.css
@@ -33,16 +33,16 @@
   align-items: flex-end;
 }
 
-.backwardsCompat .uitkMetric.uitkMetric-size-small {
+.backwardsCompat.uitkMetric.uitkMetric-size-small {
   margin-top: -5px;
 }
-.backwardsCompat .uitkMetric.uitkMetric-size-medium {
+.backwardsCompat.uitkMetric.uitkMetric-size-medium {
   margin-top: -9px;
 }
-.backwardsCompat .uitkMetric.uitkMetric-size-large {
+.backwardsCompat.uitkMetric.uitkMetric-size-large {
   margin-top: -16px;
 }
 
-.backwardsCompat .uitkMetric-orientation-vertical.uitkMetric-size-large {
+.backwardsCompat.uitkMetric-orientation-vertical.uitkMetric-size-large {
   margin-top: -14px;
 }

--- a/packages/lab/src/metric/MetricContent.css
+++ b/packages/lab/src/metric/MetricContent.css
@@ -51,16 +51,16 @@
   text-align: right;
 }
 
-.backwardsCompat .uitkMetric.uitkMetric-size-small .uitkMetricContent-subvalue {
+.backwardsCompat.uitkMetric.uitkMetric-size-small .uitkMetricContent-subvalue {
   margin-top: -2px;
 }
-.backwardsCompat .uitkMetric.uitkMetric-size-medium .uitkMetricContent-subvalue {
+.backwardsCompat.uitkMetric.uitkMetric-size-medium .uitkMetricContent-subvalue {
   margin-top: -6px;
 }
-.backwardsCompat .uitkMetric.uitkMetric-size-large .uitkMetricContent-subvalue {
+.backwardsCompat.uitkMetric.uitkMetric-size-large .uitkMetricContent-subvalue {
   margin-top: -10px;
 }
 
-.backwardsCompat .uitkMetric-orientation-vertical.uitkMetric .uitkMetricContent-subvalue {
+.backwardsCompat.uitkMetric-orientation-vertical.uitkMetric .uitkMetricContent-subvalue {
   margin-top: 0px;
 }

--- a/packages/lab/src/pill/internal/PillCheckbox.css
+++ b/packages/lab/src/pill/internal/PillCheckbox.css
@@ -6,12 +6,12 @@
 }
 
 /* Backwards compat styling to match TK1 */
-.uitk-light .backwardsCompat .uitkPill-checkbox {
+.uitk-light .backwardsCompat.uitkPill .uitkPill-checkbox {
   --uitkCheckboxIcon-stroke: var(--uitk-color-grey-100);
   --uitkCheckboxIcon-tick-color: var(--uitk-color-grey-300);
 }
 
-.uitk-dark .backwardsCompat .uitkPill-checkbox {
+.uitk-dark .backwardsCompat.uitkPill .uitkPill-checkbox {
   --uitkCheckboxIcon-stroke: var(--uitk-color-grey-80);
   --uitkCheckboxIcon-tick-color: var(--uitk-color-grey-60);
 }

--- a/packages/lab/src/radio-button/RadioButtonGroup.tsx
+++ b/packages/lab/src/radio-button/RadioButtonGroup.tsx
@@ -103,7 +103,8 @@ export const RadioButtonGroup = forwardRef<
     <fieldset
       className={classnames(
         withBaseName(),
-        row ? withBaseName("horizontal") : withBaseName("vertical")
+        row ? withBaseName("horizontal") : withBaseName("vertical"),
+        className
       )}
       data-testid="radio-button-group"
       ref={ref}
@@ -112,7 +113,7 @@ export const RadioButtonGroup = forwardRef<
     >
       {!inFormField && (
         <FormLabel
-          className={classnames(className, withBaseName("legend"))}
+          className={classnames(withBaseName("legend"))}
           label={legend}
         />
       )}

--- a/packages/lab/src/radio-button/RadioIcon.css
+++ b/packages/lab/src/radio-button/RadioIcon.css
@@ -69,10 +69,12 @@
   fill: var(--uitkRadioIcon-inner-fill, var(--uitk-selectable-primary-foreground-selected));
 }
 
-.backwardsCompat .uitk-dark .uitkRadioIcon-border {
+.uitk-dark .backwardsCompat.uitkRadioButton .uitkRadioIcon-border,
+.uitk-dark .backwardsCompat.uitkRadioButtonGroup .uitkRadioIcon-border {
   fill: var(--radioIcon-fill);
 }
 
-.backwardsCompat .uitk-dark .uitkRadioIcon-inner-checked {
+.uitk-dark .backwardsCompat.uitkRadioButton .uitkRadioIcon-inner-checked,
+.uitk-dark .backwardsCompat.uitkRadioButtonGroup .uitkRadioIcon-inner-checked {
   fill: var(--radioIcon-fill-checked);
 }

--- a/packages/lab/src/switch/Switch.css
+++ b/packages/lab/src/switch/Switch.css
@@ -206,3 +206,7 @@
 .uitkSwitch-disabled:hover {
   --switch-thumb-background: var(--uitk-selectable-foreground-selectedDisabled);
 }
+
+.uitk-dark .backwardsCompat.uitkSwitch .uitkSwitch-iconTick {
+  --uitkSwitch-icon-color-checked: var(--uitk-color-white);
+}

--- a/packages/lab/src/switch/Switch.tsx
+++ b/packages/lab/src/switch/Switch.tsx
@@ -89,7 +89,6 @@ export const Switch = forwardRef<HTMLLabelElement, SwitchProps>(function Switch(
     [onBlur]
   );
 
-  // TODO review ControlLabel
   return (
     <ControlLabel
       {...LabelProps}
@@ -102,7 +101,7 @@ export const Switch = forwardRef<HTMLLabelElement, SwitchProps>(function Switch(
       label={label}
       ref={ref}
     >
-      <span className={withBaseName()}>
+      <span className={cx(withBaseName(), className)}>
         <span
           className={cx(withBaseName("base"), {
             [withBaseName("checked")]: checked,

--- a/packages/lab/stories/checkbox.qa.stories.tsx
+++ b/packages/lab/stories/checkbox.qa.stories.tsx
@@ -8,34 +8,46 @@ export default {
   component: Checkbox,
 } as ComponentMeta<typeof Checkbox>;
 
-const Checkboxes = () => (
-  <div data-jpmui-test="checkboxes">
-    <Checkbox label="I understand ADA requires Labels on unchecked checkboxes" />
-    <Checkbox
-      defaultChecked
-      label="I understand ADA requires Labels on checked checkboxes"
-    />
-    <Checkbox
-      defaultChecked
-      indeterminate
-      label="I understand ADA requires Labels on indeterminate checkboxes"
-    />
-    <Checkbox
-      disabled
-      label="I understand ADA requires Labels on indeterminate checkboxes"
-    />
-  </div>
-);
-
-export const AllExamplesGrid: ComponentStory<typeof Checkbox> = () => {
+export const AllExamplesGrid: ComponentStory<typeof Checkbox> = (props) => {
+  const { className } = props;
   return (
     <AllRenderer className="uitkCheckboxQA">
-      <Checkboxes />
+      <div data-jpmui-test="checkboxes">
+        <Checkbox
+          className={className}
+          label="I understand ADA requires Labels on unchecked checkboxes"
+        />
+        <Checkbox
+          className={className}
+          defaultChecked
+          label="I understand ADA requires Labels on checked checkboxes"
+        />
+        <Checkbox
+          className={className}
+          defaultChecked
+          indeterminate
+          label="I understand ADA requires Labels on indeterminate checkboxes"
+        />
+        <Checkbox
+          className={className}
+          disabled
+          label="I understand ADA requires Labels on indeterminate checkboxes"
+        />
+      </div>
     </AllRenderer>
   );
 };
 
 AllExamplesGrid.parameters = {
+  chromatic: { disableSnapshot: false },
+};
+
+export const BackwardsCompatGrid = AllExamplesGrid.bind({});
+BackwardsCompatGrid.args = {
+  className: "backwardsCompat",
+};
+
+BackwardsCompatGrid.parameters = {
   chromatic: { disableSnapshot: false },
 };
 
@@ -49,9 +61,7 @@ export const CompareWithOriginalToolkit: ComponentStory<
       className="uitkCheckboxQA"
       imgSrc="/visual-regression-screenshots/Checkbox-vr-snapshot.png"
     >
-      <div className="backwardsCompat">
-        <AllExamplesGrid />
-      </div>
+      <BackwardsCompatGrid className="backwardsCompat" />
     </QAContainer>
   );
 };

--- a/packages/lab/stories/form-field.qa.stories.tsx
+++ b/packages/lab/stories/form-field.qa.stories.tsx
@@ -1,3 +1,4 @@
+import cn from "classnames";
 import { FormField, Input } from "@jpmorganchase/uitk-lab";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { AllRenderer, QAContainer } from "docs/components";
@@ -9,6 +10,7 @@ export default {
 } as ComponentMeta<typeof FormField>;
 
 export const AllExamplesGrid: ComponentStory<typeof FormField> = (props) => {
+  const { className } = props;
   return (
     <AllRenderer>
       <div
@@ -19,28 +21,20 @@ export const AllExamplesGrid: ComponentStory<typeof FormField> = (props) => {
           gap: "4px",
         }}
       >
-        <FormField
-          label="Default Form Field description label"
-          className="backwardsCompat"
-        >
+        <FormField label="Default Form Field description label">
           <Input value="Value" />
         </FormField>
 
         <FormField
+          className="uitkEmphasisHigh"
           label="Default Form Field description label"
-          className="uitkEmphasisHigh backwardsCompat"
         >
           <Input value="Value" />
         </FormField>
-        <FormField
-          label="Label aligned left"
-          labelPlacement="left"
-          className="backwardsCompat"
-        >
+        <FormField label="Label aligned left" labelPlacement="left">
           <Input value="Value" />
         </FormField>
         <FormField
-          className="backwardsCompat"
           helperText="Warning helper text"
           label="Warning Form Field"
           validationState="warning"
@@ -48,27 +42,19 @@ export const AllExamplesGrid: ComponentStory<typeof FormField> = (props) => {
           <Input />
         </FormField>
         <FormField
+          className="uitkEmphasisHigh"
           helperText="Warning helper text"
           label="Warning Form Field"
           validationState="warning"
-          className="uitkEmphasisHigh backwardsCompat"
         >
           <Input />
         </FormField>
         <FormField
+          className="uitkEmphasisLow"
           hasStatusIndicator
           helperText="Warning helper text"
           label="Warning Form Field"
           validationState="warning"
-          className="uitkEmphasisLow backwardsCompat"
-        >
-          <Input />
-        </FormField>
-        <FormField
-          className="backwardsCompat"
-          helperText="Warning helper text"
-          label="Warning Form Field"
-          validationState="error"
         >
           <Input />
         </FormField>
@@ -76,16 +62,23 @@ export const AllExamplesGrid: ComponentStory<typeof FormField> = (props) => {
           helperText="Warning helper text"
           label="Warning Form Field"
           validationState="error"
-          className="uitkEmphasisHigh backwardsCompat"
         >
           <Input />
         </FormField>
         <FormField
+          className="uitkEmphasisHigh"
+          helperText="Warning helper text"
+          label="Warning Form Field"
+          validationState="error"
+        >
+          <Input />
+        </FormField>
+        <FormField
+          className="uitkEmphasisLow"
           hasStatusIndicator
           helperText="Warning helper text"
           label="Warning Form Field"
           validationState="error"
-          className="uitkEmphasisLow backwardsCompat"
         >
           <Input />
         </FormField>

--- a/packages/lab/stories/input.qa.stories.tsx
+++ b/packages/lab/stories/input.qa.stories.tsx
@@ -56,7 +56,6 @@ export const AllExamplesGrid: ComponentStory<typeof Input> = (props) => {
         </div>
       </AllRenderer>
       <div
-        className="backwardsCompat"
         style={{
           background: "inherit",
           display: "inline-grid",

--- a/packages/lab/stories/metric.qa.stories.tsx
+++ b/packages/lab/stories/metric.qa.stories.tsx
@@ -10,87 +10,108 @@ export default {
   component: Metric,
 } as ComponentMeta<typeof Metric>;
 
-const MetricExamples = () => (
-  <div
-    data-jpmui-test="metric-example"
-    style={{
-      display: "flex",
-      flexDirection: "column",
-      width: 334,
-      padding: 0,
-    }}
-  >
-    <Metric
-      align="left"
-      direction="up"
-      size="small"
-      orientation="horizontal"
-      showIndicator
+const MetricExamples = (props: { className?: string | undefined }) => {
+  return (
+    <div
+      data-jpmui-test="metric-example"
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        width: 334,
+        padding: 0,
+      }}
     >
-      <MetricHeader subtitle="Total Value" title="Revenue YTD" />
-      <MetricContent subvalue="+10.1 (+1.23%)" value="$801.9B" />
-    </Metric>
-    <Metric
-      align="center"
-      direction="down"
-      size="medium"
-      orientation="horizontal"
-      showIndicator
-      indicatorPosition="start"
-    >
-      <MetricHeader subtitle="Total Value" title="Revenue YTD" />
-      <MetricContent subvalue="+10.1 (+1.23%)" value="$801.9B" />
-    </Metric>
-    <Metric
-      align="right"
-      size="large"
-      orientation="horizontal"
-      direction="up"
-      showIndicator
-      indicatorPosition="end"
-    >
-      <MetricHeader subtitle="Total Value" title="Revenue YTD" />
-      <MetricContent subvalue="+10.1 (+1.23%)" value="$801.9B" />
-    </Metric>
-    <Metric align="left" direction="up" size="small" showIndicator>
-      <MetricHeader subtitle="Total Value" title="Revenue YTD" />
-      <MetricContent subvalue="+10.1 (+1.23%)" value="$801.9B" />
-    </Metric>
-    <Metric align="center" direction="up" size="medium" showIndicator>
-      <MetricHeader subtitle="Total Value" title="Revenue YTD" />
-      <MetricContent subvalue="+10.1 (+1.23%)" value="$801.9B" />
-    </Metric>
-    <Metric
-      align="right"
-      direction="down"
-      size="large"
-      indicatorPosition="start"
-      showIndicator
-    >
-      <MetricHeader subtitle="Total Value" title="Revenue YTD" />
-      <MetricContent subvalue="+10.1 (+1.23%)" value="$801.9B" />
-    </Metric>
-  </div>
-);
+      <Metric
+        align="left"
+        className={props.className}
+        direction="up"
+        size="small"
+        orientation="horizontal"
+        showIndicator
+      >
+        <MetricHeader subtitle="Total Value" title="Revenue YTD" />
+        <MetricContent subvalue="+10.1 (+1.23%)" value="$801.9B" />
+      </Metric>
+      <Metric
+        align="center"
+        className={props.className}
+        direction="down"
+        size="medium"
+        orientation="horizontal"
+        showIndicator
+        indicatorPosition="start"
+      >
+        <MetricHeader subtitle="Total Value" title="Revenue YTD" />
+        <MetricContent subvalue="+10.1 (+1.23%)" value="$801.9B" />
+      </Metric>
+      <Metric
+        align="right"
+        className={props.className}
+        size="large"
+        orientation="horizontal"
+        direction="up"
+        showIndicator
+        indicatorPosition="end"
+      >
+        <MetricHeader subtitle="Total Value" title="Revenue YTD" />
+        <MetricContent subvalue="+10.1 (+1.23%)" value="$801.9B" />
+      </Metric>
+      <Metric
+        align="left"
+        className={props.className}
+        direction="up"
+        size="small"
+        showIndicator
+      >
+        <MetricHeader subtitle="Total Value" title="Revenue YTD" />
+        <MetricContent subvalue="+10.1 (+1.23%)" value="$801.9B" />
+      </Metric>
+      <Metric align="center" direction="up" size="medium" showIndicator>
+        <MetricHeader subtitle="Total Value" title="Revenue YTD" />
+        <MetricContent subvalue="+10.1 (+1.23%)" value="$801.9B" />
+      </Metric>
+      <Metric
+        align="right"
+        className={props.className}
+        direction="down"
+        size="large"
+        indicatorPosition="start"
+        showIndicator
+      >
+        <MetricHeader subtitle="Total Value" title="Revenue YTD" />
+        <MetricContent subvalue="+10.1 (+1.23%)" value="$801.9B" />
+      </Metric>
+    </div>
+  );
+};
 
-export const ExamplesGrid: Story = (props) => {
+export const AllExamplesGrid: Story = (props: { className?: string }) => {
   return (
     <div style={{ width: 800, display: "flex", flex: 1 }} {...props}>
       <ToolkitProvider theme={"light"}>
         <BackgroundBlock style={{ background: "white" }}>
-          <MetricExamples />
+          <MetricExamples className={props.className} />
         </BackgroundBlock>
       </ToolkitProvider>
       <ToolkitProvider theme={"dark"}>
         <BackgroundBlock>
-          <MetricExamples />
+          <MetricExamples className={props.className} />
         </BackgroundBlock>
       </ToolkitProvider>
     </div>
   );
 };
 
-ExamplesGrid.parameters = {
+AllExamplesGrid.parameters = {
+  chromatic: { disableSnapshot: false },
+};
+
+export const BackwardsCompatGrid = AllExamplesGrid.bind({});
+BackwardsCompatGrid.args = {
+  className: "backwardsCompat",
+};
+
+BackwardsCompatGrid.parameters = {
   chromatic: { disableSnapshot: false },
 };
 
@@ -101,7 +122,7 @@ export const CompareWithOriginalToolkit: ComponentStory<typeof Metric> = () => {
       className="uitkMetricQA"
       imgSrc="/visual-regression-screenshots/Metric-vr-snapshot.png"
     >
-      <ExamplesGrid className="backwardsCompat" />
+      <BackwardsCompatGrid className="backwardsCompat" />
     </QAContainer>
   );
 };

--- a/packages/lab/stories/radio-button.qa.stories.tsx
+++ b/packages/lab/stories/radio-button.qa.stories.tsx
@@ -13,6 +13,7 @@ export default {
 } as ComponentMeta<typeof RadioButton>;
 
 export const AllExamplesGrid: ComponentStory<typeof RadioButton> = (props) => {
+  const { className } = props;
   return (
     <AllRenderer>
       <>
@@ -25,6 +26,7 @@ export const AllExamplesGrid: ComponentStory<typeof RadioButton> = (props) => {
           }}
         >
           <RadioButtonGroup
+            className={className}
             aria-label="Uncontrolled Example"
             defaultValue="forward"
             legend="Example"
@@ -39,7 +41,13 @@ export const AllExamplesGrid: ComponentStory<typeof RadioButton> = (props) => {
             />
           </RadioButtonGroup>
         </div>
-        <RadioButtonGroup defaultValue="forward" legend="Example" name="fx" row>
+        <RadioButtonGroup
+          className={className}
+          defaultValue="forward"
+          legend="Example"
+          name="fx"
+          row
+        >
           <RadioButton key="spot" label="Spot" value="spot" />
           <RadioButton key="forward" label="Forward" value="forward" />
           <RadioButton
@@ -58,6 +66,15 @@ AllExamplesGrid.parameters = {
   chromatic: { disableSnapshot: false },
 };
 
+export const BackwardsCompatGrid = AllExamplesGrid.bind({});
+BackwardsCompatGrid.args = {
+  className: "backwardsCompat",
+};
+
+BackwardsCompatGrid.parameters = {
+  chromatic: { disableSnapshot: false },
+};
+
 export const CompareWithOriginalToolkit: ComponentStory<typeof RadioButton> = (
   props
 ) => {
@@ -68,9 +85,7 @@ export const CompareWithOriginalToolkit: ComponentStory<typeof RadioButton> = (
       height={605}
       imgSrc="/visual-regression-screenshots/RadioButton-vr-snapshot.png"
     >
-      <div className="backwardsCompat">
-        <AllExamplesGrid />
-      </div>
+      <BackwardsCompatGrid className="backwardsCompat" />
     </QAContainer>
   );
 };

--- a/packages/lab/stories/switch.qa.stories.css
+++ b/packages/lab/stories/switch.qa.stories.css
@@ -1,6 +1,3 @@
 .uitkSwitchQA .uitkDocGrid {
   min-height: 174px;
 }
-.uitkSwitchQA .uitk-dark .uitkSwitch-iconTick {
-  --uitkSwitch-icon-color-checked: var(--uitk-color-white);
-}

--- a/packages/lab/stories/switch.qa.stories.tsx
+++ b/packages/lab/stories/switch.qa.stories.tsx
@@ -12,25 +12,8 @@ export default {
   argTypes: { onClick: { action: "clicked" } },
 } as ComponentMeta<typeof Switch>;
 
-const SwitchExamples = [
-  <Switch className="backwardsCompat" key="Default" label="Default" />,
-  <Switch
-    className="backwardsCompat"
-    defaultChecked
-    key="Default"
-    label="Default"
-  />,
-  <Switch className="backwardsCompat" disabled key="Default" label="Default" />,
-  <Switch
-    className="backwardsCompat"
-    defaultChecked
-    disabled
-    key="Default"
-    label="Default"
-  />,
-];
-
 export const AllExamplesGrid: ComponentStory<typeof Switch> = (props) => {
+  const { className } = props;
   return (
     <AllRenderer>
       <div
@@ -41,15 +24,36 @@ export const AllExamplesGrid: ComponentStory<typeof Switch> = (props) => {
           gap: "4px",
         }}
       >
-        {SwitchExamples.map((s) => (
-          <>{s}</>
-        ))}
+        <Switch className={className} key="Default" label="Default" />
+        <Switch
+          className={className}
+          defaultChecked
+          key="Default"
+          label="Default"
+        />
+        <Switch className={className} disabled key="Default" label="Default" />
+        <Switch
+          className={className}
+          defaultChecked
+          disabled
+          key="Default"
+          label="Default"
+        />
       </div>
     </AllRenderer>
   );
 };
 
 AllExamplesGrid.parameters = {
+  chromatic: { disableSnapshot: false },
+};
+
+export const BackwardsCompatGrid = AllExamplesGrid.bind({});
+BackwardsCompatGrid.args = {
+  className: "backwardsCompat",
+};
+
+BackwardsCompatGrid.parameters = {
   chromatic: { disableSnapshot: false },
 };
 
@@ -62,7 +66,7 @@ export const CompareWithOriginalToolkit: ComponentStory<typeof Switch> = (
       className="uitkSwitchQA"
       imgSrc="/visual-regression-screenshots/Switch-vr-snapshot.png"
     >
-      <AllExamplesGrid />
+      <BackwardsCompatGrid className="backwardsCompat" />
     </QAContainer>
   );
 };


### PR DESCRIPTION
Includes taking chromatic screenshot of backwards compat story if applicable for component

**Standardisation**:
- AllExamplesGrid: has new Odyssey styling (screenshotted)
- BackwardsCompatGrid: overrides AllExamplesGrid with backwardsCompat className (screenshotted)
- TK1 VR: Uses BackwardsCompatGrid
- Class name "backwardsCompat" should be applied to the root of the component along with it's base name. Then, CSS should be specific selecting that component i.e. .backwardsCompat.uitkCheckbox (no space). 

_Note 1_: it may be necessary to have the class applied in two places depending on how component can be used, e.g. .backwardsCompat.uitkRadioButton and .backwardsCompat.uitkRadioButtonGroup

_Note 2_: if it is a shared component, e.g. ControlLabel, it is best to use .backwardsCompat .uitkControlLabel (with space) - but this will reflect across any components using ControlLabel, which may be an undesired effect