### PR TITLE
Wrap by default on FlexLayout and tweak layout storybook examples

### DIFF
--- a/.changeset/spicy-worms-clap.md
+++ b/.changeset/spicy-worms-clap.md
@@ -1,0 +1,5 @@
+---
+"@jpmorganchase/uitk-core": minor
+---
+
+Change FlexLayout component to wrap by default

--- a/packages/core/src/__tests__/__e2e__/layout/Flex.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/layout/Flex.cy.tsx
@@ -17,10 +17,10 @@ describe("GIVEN a Flex", () => {
       cy.get(".uitkFlexLayout").should("have.css", "flex-direction", "row");
     });
 
-    it("THEN it should render with no flex wrap", () => {
+    it("THEN it should render with flex wrap", () => {
       cy.mount(<DefaultFlexLayout />);
 
-      cy.get(".uitkFlexLayout").should("have.css", "flex-wrap", "nowrap");
+      cy.get(".uitkFlexLayout").should("have.css", "flex-wrap", "wrap");
     });
 
     it("THEN it should render with a default gap", () => {
@@ -34,13 +34,13 @@ describe("GIVEN a Flex", () => {
     it("THEN nested items should not inherit css variables from parent", () => {
       cy.mount(<FlexLayoutNested />);
 
-      cy.get(".uitkFlexLayout").eq(0).should("have.css", "flex-wrap", "wrap");
+      cy.get(".uitkFlexLayout").eq(0).should("have.css", "flex-wrap", "nowrap");
       cy.get(".uitkFlexLayout")
         .eq(0)
         .should("have.css", "justify-content", "space-between");
       cy.get(".uitkFlexLayout").eq(0).should("have.css", "row-gap", "48px");
 
-      cy.get(".uitkFlexLayout").eq(1).should("have.css", "flex-wrap", "nowrap");
+      cy.get(".uitkFlexLayout").eq(1).should("have.css", "flex-wrap", "wrap");
       cy.get(".uitkFlexLayout")
         .eq(1)
         .should("have.css", "justify-content", "flex-start");

--- a/packages/core/src/__tests__/__e2e__/layout/Flex.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/layout/Flex.cy.tsx
@@ -17,12 +17,6 @@ describe("GIVEN a Flex", () => {
       cy.get(".uitkFlexLayout").should("have.css", "flex-direction", "row");
     });
 
-    it("THEN it should render with no flex wrap", () => {
-      cy.mount(<DefaultFlexLayout />);
-
-      cy.get(".uitkFlexLayout").should("have.css", "flex-wrap", "nowrap");
-    });
-
     it("THEN it should render with a default gap", () => {
       cy.mount(<DefaultFlexLayout />);
 
@@ -56,6 +50,14 @@ describe("GIVEN a Flex", () => {
         "have.class",
         "uitkFlexLayout-separator"
       );
+    });
+  });
+
+  describe("WHEN wrap is set to true", () => {
+    it("THEN it should render with flex wrap", () => {
+      cy.mount(<DefaultFlexLayout wrap={true} />);
+
+      cy.get(".uitkFlexLayout").should("have.css", "flex-wrap", "wrap");
     });
   });
 

--- a/packages/core/src/__tests__/__e2e__/layout/Flex.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/layout/Flex.cy.tsx
@@ -61,19 +61,19 @@ describe("GIVEN a Flex", () => {
 
   describe("WHEN wrap is set to true", () => {
     it("THEN it should render with flex wrap", () => {
-      cy.mount(<DefaultFlexLayout wrap={true} />);
+      cy.mount(<DefaultFlexLayout disableWrap={false} />);
 
       cy.get(".uitkFlexLayout").should("have.css", "flex-wrap", "wrap");
     });
   });
 
   describe("WHEN responsive values are provided", () => {
-    const wrap = {
-      xs: true,
-      sm: true,
-      md: true,
-      lg: false,
-      xl: false,
+    const disableWrap = {
+      xs: false,
+      sm: false,
+      md: false,
+      lg: true,
+      xl: true,
     };
 
     it(
@@ -83,7 +83,7 @@ describe("GIVEN a Flex", () => {
         viewportWidth: 1921,
       },
       () => {
-        cy.mount(<ToolkitFlexLayoutResponsive wrap={wrap} />);
+        cy.mount(<ToolkitFlexLayoutResponsive disableWrap={disableWrap} />);
 
         cy.get(".uitkFlexLayout").should("have.css", "flex-wrap", "nowrap");
       }
@@ -96,7 +96,7 @@ describe("GIVEN a Flex", () => {
         viewportWidth: 961,
       },
       () => {
-        cy.mount(<ToolkitFlexLayoutResponsive wrap={wrap} />);
+        cy.mount(<ToolkitFlexLayoutResponsive disableWrap={disableWrap} />);
 
         cy.get(".uitkFlexLayout").should("have.css", "flex-wrap", "wrap");
       }
@@ -109,7 +109,7 @@ describe("GIVEN a Flex", () => {
         viewportWidth: 700,
       },
       () => {
-        cy.mount(<ToolkitFlexLayoutResponsive wrap={wrap} />);
+        cy.mount(<ToolkitFlexLayoutResponsive disableWrap={disableWrap} />);
 
         cy.get(".uitkFlexLayout").should("have.css", "flex-wrap", "wrap");
       }
@@ -122,7 +122,7 @@ describe("GIVEN a Flex", () => {
         viewportWidth: 600,
       },
       () => {
-        cy.mount(<ToolkitFlexLayoutResponsive wrap={wrap} />);
+        cy.mount(<ToolkitFlexLayoutResponsive disableWrap={disableWrap} />);
 
         cy.get(".uitkFlexLayout").should("have.css", "flex-wrap", "wrap");
       }
@@ -130,12 +130,12 @@ describe("GIVEN a Flex", () => {
   });
 
   describe("WHEN custom breakpoints are provided", () => {
-    const wrap = {
-      xs: true,
-      sm: true,
-      md: true,
-      lg: false,
-      xl: false,
+    const disableWrap = {
+      xs: false,
+      sm: false,
+      md: false,
+      lg: true,
+      xl: true,
     };
 
     const breakpoints = {
@@ -155,7 +155,7 @@ describe("GIVEN a Flex", () => {
       () => {
         cy.mount(
           <ToolkitProvider breakpoints={breakpoints}>
-            <ToolkitFlexLayoutResponsive wrap={wrap} />
+            <ToolkitFlexLayoutResponsive disableWrap={disableWrap} />
           </ToolkitProvider>
         );
 
@@ -172,7 +172,7 @@ describe("GIVEN a Flex", () => {
       () => {
         cy.mount(
           <ToolkitProvider breakpoints={breakpoints}>
-            <ToolkitFlexLayoutResponsive wrap={wrap} />
+            <ToolkitFlexLayoutResponsive disableWrap={disableWrap} />
           </ToolkitProvider>
         );
 
@@ -189,7 +189,7 @@ describe("GIVEN a Flex", () => {
       () => {
         cy.mount(
           <ToolkitProvider breakpoints={breakpoints}>
-            <ToolkitFlexLayoutResponsive wrap={wrap} />
+            <ToolkitFlexLayoutResponsive disableWrap={disableWrap} />
           </ToolkitProvider>
         );
 
@@ -206,7 +206,7 @@ describe("GIVEN a Flex", () => {
       () => {
         cy.mount(
           <ToolkitProvider breakpoints={breakpoints}>
-            <ToolkitFlexLayoutResponsive wrap={wrap} />
+            <ToolkitFlexLayoutResponsive disableWrap={disableWrap} />
           </ToolkitProvider>
         );
 

--- a/packages/core/src/__tests__/__e2e__/layout/Flex.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/layout/Flex.cy.tsx
@@ -17,6 +17,12 @@ describe("GIVEN a Flex", () => {
       cy.get(".uitkFlexLayout").should("have.css", "flex-direction", "row");
     });
 
+    it("THEN it should render with no flex wrap", () => {
+      cy.mount(<DefaultFlexLayout />);
+
+      cy.get(".uitkFlexLayout").should("have.css", "flex-wrap", "nowrap");
+    });
+
     it("THEN it should render with a default gap", () => {
       cy.mount(<DefaultFlexLayout />);
 

--- a/packages/core/src/layout/FlexItem/FlexItem.tsx
+++ b/packages/core/src/layout/FlexItem/FlexItem.tsx
@@ -4,7 +4,12 @@ import "./FlexItem.css";
 import cx from "classnames";
 
 const withBaseName = makePrefixer("uitkFlexItem");
-export const FLEX_ITEM_ALIGNMENTS = ["start", "end", "center", "stretch"];
+export const FLEX_ITEM_ALIGNMENTS = [
+  "start",
+  "end",
+  "center",
+  "stretch",
+] as const;
 
 export type flexItemAlignment = typeof FLEX_ITEM_ALIGNMENTS[number];
 

--- a/packages/core/src/layout/FlexItem/FlexItem.tsx
+++ b/packages/core/src/layout/FlexItem/FlexItem.tsx
@@ -15,17 +15,16 @@ export type flexItemAlignment = typeof FLEX_ITEM_ALIGNMENTS[number];
 
 export interface FlexItemProps extends HTMLAttributes<HTMLDivElement> {
   /**
-   * Allows the alignment specified by parent to be overridden for individual items.
+   * Allows the alignment specified by parent to be overridden for individual items, default is "start".
    */
   align?: flexItemAlignment;
   /**
-   * Defines the ability for an item to shrink x times more compared to it's siblings,
-   *default is 1
+   * Defines the ability for an item to shrink x times more compared to it's siblings, default is 1.
+   
    */
   shrink?: ResponsiveProp<number>;
   /**
-   * Defines the ability for an item to grow x times more compared to it's siblings,
-   * default is 0
+   * Defines the ability for an item to grow x times more compared to it's siblings, default is 0.
    */
   grow?: ResponsiveProp<number>;
 }

--- a/packages/core/src/layout/FlexLayout/FlexLayout.css
+++ b/packages/core/src/layout/FlexLayout/FlexLayout.css
@@ -7,7 +7,7 @@
   --flex-layout-gap-multiplier: var(--flex-layout-gap-density-multiplier, 3);
   --flex-layout-layout-display: flex;
   --flex-layout-direction: row;
-  --flex-layout-wrap: nowrap;
+  --flex-layout-wrap: wrap;
   --flex-layout-justify: flex-start;
   --flex-layout-align: stretch;
   --flex-layout-separator: var(--uitk-separable-borderWidth);

--- a/packages/core/src/layout/FlexLayout/FlexLayout.tsx
+++ b/packages/core/src/layout/FlexLayout/FlexLayout.tsx
@@ -21,11 +21,11 @@ export type FlexContentAlignment = typeof FLEX_CONTENT_ALIGNMENT_BASE[number];
 
 export interface FlexLayoutProps extends HTMLAttributes<HTMLDivElement> {
   /**
-   * Defines the default behavior for how flex items are laid out along the cross axis on the current line.
+   * Defines the default behavior for how flex items are laid out along the cross axis on the current line, default is "stretch".
    */
   align?: FlexAlignment | "stretch" | "baseline";
   /**
-   * Establishes the main-axis, defining the direction children are placed.
+   * Establishes the main-axis, defining the direction children are placed. Default is "row".
    */
   direction?: ResponsiveProp<LayoutDirection>;
   /**
@@ -33,11 +33,11 @@ export interface FlexLayoutProps extends HTMLAttributes<HTMLDivElement> {
    */
   gap?: ResponsiveProp<number>;
   /**
-   * Defines the alignment along the main axis.
+   * Defines the alignment along the main axis, default is "start".
    */
   justify?: FlexContentAlignment;
   /**
-   * Adds a separator between elements.
+   * Adds a separator between elements, default is false.
    */
   separators?: LayoutSeparator | true;
   /**

--- a/packages/core/src/layout/FlexLayout/FlexLayout.tsx
+++ b/packages/core/src/layout/FlexLayout/FlexLayout.tsx
@@ -29,7 +29,7 @@ export interface FlexLayoutProps extends HTMLAttributes<HTMLDivElement> {
    */
   direction?: ResponsiveProp<LayoutDirection>;
   /**
-   * Controls the space between items.
+   * Controls the space between items, default is 3.
    */
   gap?: ResponsiveProp<number>;
   /**

--- a/packages/core/src/layout/FlexLayout/FlexLayout.tsx
+++ b/packages/core/src/layout/FlexLayout/FlexLayout.tsx
@@ -41,7 +41,7 @@ export interface FlexLayoutProps extends HTMLAttributes<HTMLDivElement> {
    */
   separators?: LayoutSeparator | true;
   /**
-   * Allow the items to wrap as needed, default is false.
+   * Allow the items to wrap as needed, default is true.
    */
   wrap?: ResponsiveProp<boolean>;
 }
@@ -57,7 +57,7 @@ export const FlexLayout = forwardRef<HTMLDivElement, FlexLayoutProps>(
       justify,
       separators,
       style,
-      wrap,
+      wrap = true,
       ...rest
     },
     ref
@@ -69,7 +69,8 @@ export const FlexLayout = forwardRef<HTMLDivElement, FlexLayoutProps>(
 
     const flexGap = useResponsiveProp(gap, 3);
     const flexDirection = useResponsiveProp(direction, "row");
-    const flexWrap = useResponsiveProp(wrap, false);
+    const flexWrap = useResponsiveProp(wrap, true);
+
     const flexLayoutStyles = {
       ...style,
       "--flex-layout-align": align && addPrefix(align),

--- a/packages/core/src/layout/FlexLayout/FlexLayout.tsx
+++ b/packages/core/src/layout/FlexLayout/FlexLayout.tsx
@@ -41,9 +41,9 @@ export interface FlexLayoutProps extends HTMLAttributes<HTMLDivElement> {
    */
   separators?: LayoutSeparator | true;
   /**
-   * Allow the items to wrap as needed, default is true.
+   * Disable wrapping so flex items try to fit onto one line, default is false.
    */
-  wrap?: ResponsiveProp<boolean>;
+  disableWrap?: ResponsiveProp<boolean>;
 }
 
 export const FlexLayout = forwardRef<HTMLDivElement, FlexLayoutProps>(
@@ -57,7 +57,7 @@ export const FlexLayout = forwardRef<HTMLDivElement, FlexLayoutProps>(
       justify,
       separators,
       style,
-      wrap = true,
+      disableWrap = false,
       ...rest
     },
     ref
@@ -69,7 +69,7 @@ export const FlexLayout = forwardRef<HTMLDivElement, FlexLayoutProps>(
 
     const flexGap = useResponsiveProp(gap, 3);
     const flexDirection = useResponsiveProp(direction, "row");
-    const flexWrap = useResponsiveProp(wrap, true);
+    const flexDisableWrap = useResponsiveProp(disableWrap, true);
 
     const flexLayoutStyles = {
       ...style,
@@ -77,7 +77,7 @@ export const FlexLayout = forwardRef<HTMLDivElement, FlexLayoutProps>(
       "--flex-layout-direction": flexDirection,
       "--flex-layout-gap-multiplier": flexGap,
       "--flex-layout-justify": justify && addPrefix(justify),
-      "--flex-layout-wrap": flexWrap ? "wrap" : "nowrap",
+      "--flex-layout-wrap": flexDisableWrap ? "nowrap" : "wrap",
     };
 
     return (

--- a/packages/core/src/layout/FlowLayout/FlowLayout.tsx
+++ b/packages/core/src/layout/FlowLayout/FlowLayout.tsx
@@ -3,19 +3,19 @@ import { FlexLayout, FlexLayoutProps } from "../FlexLayout";
 
 export interface FlowLayoutProps extends HTMLAttributes<HTMLDivElement> {
   /**
-   * Defines the default behavior for how flex items are laid out along the cross axis on the current line.
+   * Defines the default behavior for how flex items are laid out along the cross axis on the current line, , default is "stretch".
    */
   align?: FlexLayoutProps["align"];
   /**
-   * Controls the space between items.
+   * Controls the space between items, default is 3.
    */
   gap?: FlexLayoutProps["gap"];
   /**
-   * Defines the alignment along the main axis.
+   * Defines the alignment along the main axis, default is "start"
    */
   justify?: FlexLayoutProps["justify"];
   /**
-   * Adds a separator between elements.
+   * Adds a separator between elements, default is false.
    */
   separators?: FlexLayoutProps["separators"];
 }

--- a/packages/core/src/layout/FlowLayout/FlowLayout.tsx
+++ b/packages/core/src/layout/FlowLayout/FlowLayout.tsx
@@ -21,6 +21,8 @@ export interface FlowLayoutProps extends HTMLAttributes<HTMLDivElement> {
 }
 export const FlowLayout = forwardRef<HTMLDivElement, FlowLayoutProps>(
   function FlowLayout({ ...rest }, ref) {
-    return <FlexLayout direction="row" ref={ref} wrap={true} {...rest} />;
+    return (
+      <FlexLayout direction="row" ref={ref} disableWrap={false} {...rest} />
+    );
   }
 );

--- a/packages/core/src/layout/ParentChildLayout/ParentChildLayout.tsx
+++ b/packages/core/src/layout/ParentChildLayout/ParentChildLayout.tsx
@@ -114,7 +114,7 @@ export const ParentChildLayout = forwardRef<
     <FlexLayout
       className={cx(className, withBaseName())}
       ref={ref}
-      wrap={false}
+      disableWrap
       {...rest}
     >
       {stackedView ? (

--- a/packages/core/src/layout/SplitLayout/SplitLayout.tsx
+++ b/packages/core/src/layout/SplitLayout/SplitLayout.tsx
@@ -22,9 +22,9 @@ export interface SplitLayoutProps extends HTMLAttributes<HTMLDivElement> {
    */
   separators?: FlexLayoutProps["separators"];
   /**
-   * Allow the items to wrap as needed, default is true.
+   * Disable wrapping so flex items try to fit onto one line, default is false.
    */
-  wrap?: FlexLayoutProps["wrap"];
+  disableWrap?: FlexLayoutProps["disableWrap"];
   /**
    * Controls the space between items.
    */
@@ -59,7 +59,7 @@ export const SplitLayout = forwardRef<HTMLDivElement, SplitLayoutProps>(
       leftSplitItem,
       rightSplitItem,
       separators,
-      wrap = true,
+      disableWrap = false,
       className,
       gap,
       ...rest
@@ -70,7 +70,7 @@ export const SplitLayout = forwardRef<HTMLDivElement, SplitLayoutProps>(
       <FlexLayout
         direction="row"
         ref={ref}
-        wrap={wrap}
+        disableWrap={disableWrap}
         gap={gap}
         separators={separators}
         className={cx(withBaseName(), className)}

--- a/packages/core/src/layout/StackLayout/StackLayout.tsx
+++ b/packages/core/src/layout/StackLayout/StackLayout.tsx
@@ -3,15 +3,15 @@ import { FlexLayout, FlexLayoutProps } from "../FlexLayout";
 
 export interface StackLayoutProps extends HTMLAttributes<HTMLDivElement> {
   /**
-   * Defines the default behavior for how flex items are laid out along the cross axis on the current line.
+   * Defines the default behavior for how flex items are laid out along the cross axis on the current line, default is "stretch".
    */
   align?: FlexLayoutProps["align"];
   /**
-   * Controls the space between items.
+   * Controls the space between items, default is 3.
    */
   gap?: FlexLayoutProps["gap"];
   /**
-   * Adds a separator between elements.
+   * Adds a separator between elements, default is false.
    */
   separators?: FlexLayoutProps["separators"];
 }

--- a/packages/core/src/layout/StackLayout/StackLayout.tsx
+++ b/packages/core/src/layout/StackLayout/StackLayout.tsx
@@ -19,7 +19,7 @@ export interface StackLayoutProps extends HTMLAttributes<HTMLDivElement> {
 export const StackLayout = forwardRef<HTMLDivElement, StackLayoutProps>(
   function StackLayout({ children, ...rest }, ref) {
     return (
-      <FlexLayout direction="column" wrap={false} ref={ref} {...rest}>
+      <FlexLayout direction="column" disableWrap ref={ref} {...rest}>
         {children}
       </FlexLayout>
     );

--- a/packages/core/src/layout/types.ts
+++ b/packages/core/src/layout/types.ts
@@ -1,7 +1,6 @@
-export type LayoutDirection = "row" | "column";
-
+export const LAYOUT_DIRECTION = ["row", "column"] as const;
+export type LayoutDirection = typeof LAYOUT_DIRECTION[number];
 export type LayoutSeparator = "start" | "center" | "end";
-
 export type LayoutAnimation = "slide" | "fade";
 export type LayoutAnimationDirection = "horizontal" | "vertical";
 export type LayoutAnimationTransition = "increase" | "decrease";

--- a/packages/core/stories/layout/border-layout.stories.tsx
+++ b/packages/core/stories/layout/border-layout.stories.tsx
@@ -321,7 +321,7 @@ const Contacts: ComponentStory<typeof BorderLayout> = (args) => {
       <BorderItem position="main">
         <div className="border-layout-contacts">
           <h2>My contacts</h2>
-          <FlexLayoutComposite wrap={true} />
+          <FlexLayoutComposite />
         </div>
       </BorderItem>
 

--- a/packages/core/stories/layout/flex-item.stories.tsx
+++ b/packages/core/stories/layout/flex-item.stories.tsx
@@ -25,15 +25,22 @@ interface FlexContentProps extends HTMLAttributes<HTMLDivElement> {
   children?: ReactNode;
   caption?: string;
   classname?: string;
+  number?: number;
 }
 
 export const FlexContent = ({
   children,
   classname,
+  number,
   ...rest
 }: FlexContentProps) => (
   <div className={classname || "layout-content"} {...rest}>
-    {children || <p>Lorem ipsum dolor sit amet, consectetur adipisicing.</p>}
+    {children || (
+      <p>
+        {number && `${number}. `}Lorem ipsum dolor sit amet, consectetur
+        adipisicing.
+      </p>
+    )}
   </div>
 );
 

--- a/packages/core/stories/layout/flex-item.stories.tsx
+++ b/packages/core/stories/layout/flex-item.stories.tsx
@@ -39,7 +39,7 @@ export const FlexContent = ({
 
 const FlexItemStory: ComponentStory<typeof FlexItem> = (args) => {
   return (
-    <FlexLayout style={{ width: "50vw" }}>
+    <FlexLayout wrap={false} style={{ width: "50vw" }}>
       <FlexItem style={{ width: "100%" }} {...args}>
         <FlexContent classname={"layout-active-content"} />
       </FlexItem>

--- a/packages/core/stories/layout/flex-item.stories.tsx
+++ b/packages/core/stories/layout/flex-item.stories.tsx
@@ -39,17 +39,17 @@ export const FlexContent = ({
 
 const FlexItemStory: ComponentStory<typeof FlexItem> = (args) => {
   return (
-    <FlexLayout>
-      <FlexItem {...args}>
+    <FlexLayout style={{ width: "50vw" }}>
+      <FlexItem style={{ width: "100%" }} {...args}>
         <FlexContent classname={"layout-active-content"} />
       </FlexItem>
-      <FlexItem>
+      <FlexItem style={{ width: "100%" }}>
         <FlexContent>
           <p>Lorem ipsum dolor sit amet, consectetur adipisicing.</p>
           <p>Lorem ipsum dolor sit amet, consectetur adipisicing.</p>
         </FlexContent>
       </FlexItem>
-      <FlexItem>
+      <FlexItem style={{ width: "100%" }}>
         <FlexContent>
           <p>Lorem ipsum dolor sit amet, consectetur adipisicing.</p>
           <p>Lorem ipsum dolor sit amet, consectetur adipisicing.</p>
@@ -60,6 +60,6 @@ const FlexItemStory: ComponentStory<typeof FlexItem> = (args) => {
 };
 export const FlexItemWrapper = FlexItemStory.bind({});
 FlexItemWrapper.args = {
-  shrink: 0,
+  shrink: 1,
   grow: 0,
 };

--- a/packages/core/stories/layout/flex-item.stories.tsx
+++ b/packages/core/stories/layout/flex-item.stories.tsx
@@ -46,17 +46,17 @@ export const FlexContent = ({
 
 const FlexItemStory: ComponentStory<typeof FlexItem> = (args) => {
   return (
-    <FlexLayout wrap={false} style={{ width: "50vw" }}>
-      <FlexItem style={{ width: "100%" }} {...args}>
+    <FlexLayout wrap={false}>
+      <FlexItem {...args}>
         <FlexContent classname={"layout-active-content"} />
       </FlexItem>
-      <FlexItem style={{ width: "100%" }}>
+      <FlexItem>
         <FlexContent>
           <p>Lorem ipsum dolor sit amet, consectetur adipisicing.</p>
           <p>Lorem ipsum dolor sit amet, consectetur adipisicing.</p>
         </FlexContent>
       </FlexItem>
-      <FlexItem style={{ width: "100%" }}>
+      <FlexItem>
         <FlexContent>
           <p>Lorem ipsum dolor sit amet, consectetur adipisicing.</p>
           <p>Lorem ipsum dolor sit amet, consectetur adipisicing.</p>

--- a/packages/core/stories/layout/flex-item.stories.tsx
+++ b/packages/core/stories/layout/flex-item.stories.tsx
@@ -46,7 +46,7 @@ export const FlexContent = ({
 
 const FlexItemStory: ComponentStory<typeof FlexItem> = (args) => {
   return (
-    <FlexLayout wrap={false}>
+    <FlexLayout disableWrap>
       <FlexItem {...args}>
         <FlexContent classname={"layout-active-content"} />
       </FlexItem>

--- a/packages/core/stories/layout/flex-layout.stories.tsx
+++ b/packages/core/stories/layout/flex-layout.stories.tsx
@@ -175,5 +175,6 @@ const FlexLayoutNestedExample: ComponentStory<typeof FlexLayout> = (args) => {
 export const FlexLayoutNested = FlexLayoutNestedExample.bind({});
 FlexLayoutNested.args = {
   justify: "space-between",
+  wrap: false,
   gap: 6,
 };

--- a/packages/core/stories/layout/flex-layout.stories.tsx
+++ b/packages/core/stories/layout/flex-layout.stories.tsx
@@ -46,7 +46,7 @@ export default {
       options: ["start", "center", "end", true],
       control: { type: "select" },
     },
-    wrap: {
+    disableWrap: {
       control: "boolean",
     },
   },
@@ -96,9 +96,9 @@ ToolkitFlexLayoutResponsive.args = {
     xs: "column",
     md: "row",
   },
-  wrap: {
-    xs: true,
-    lg: false,
+  disableWrap: {
+    xs: false,
+    lg: true,
   },
 };
 
@@ -175,6 +175,6 @@ const FlexLayoutNestedExample: ComponentStory<typeof FlexLayout> = (args) => {
 export const FlexLayoutNested = FlexLayoutNestedExample.bind({});
 FlexLayoutNested.args = {
   justify: "space-between",
-  wrap: false,
+  disableWrap: true,
   gap: 6,
 };

--- a/packages/core/stories/layout/flex-layout.stories.tsx
+++ b/packages/core/stories/layout/flex-layout.stories.tsx
@@ -123,9 +123,6 @@ const FlexLayoutStorySimpleUsage: ComponentStory<typeof FlexLayout> = (
   );
 };
 export const FlexLayoutSimpleUsage = FlexLayoutStorySimpleUsage.bind({});
-FlexLayoutSimpleUsage.args = {
-  wrap: true,
-};
 
 export const ContactDetailsExample = ({ index }: { index: number }) => (
   <ContactDetails embedded={true}>
@@ -157,9 +154,6 @@ const ContactCards: ComponentStory<typeof FlexLayout> = (args) => {
   );
 };
 export const FlexLayoutComposite = ContactCards.bind({});
-FlexLayoutComposite.args = {
-  wrap: true,
-};
 
 const FlexLayoutNestedExample: ComponentStory<typeof FlexLayout> = (args) => {
   return (
@@ -182,5 +176,4 @@ export const FlexLayoutNested = FlexLayoutNestedExample.bind({});
 FlexLayoutNested.args = {
   justify: "space-between",
   gap: 6,
-  wrap: true,
 };

--- a/packages/core/stories/layout/flex-layout.stories.tsx
+++ b/packages/core/stories/layout/flex-layout.stories.tsx
@@ -50,9 +50,6 @@ export default {
       control: "boolean",
     },
   },
-  args: {
-    wrap: true,
-  },
   excludeStories: ["ContactDetailsExample", "FlexLayoutNestedExample"],
 } as ComponentMeta<typeof FlexLayout>;
 
@@ -126,6 +123,9 @@ const FlexLayoutStorySimpleUsage: ComponentStory<typeof FlexLayout> = (
   );
 };
 export const FlexLayoutSimpleUsage = FlexLayoutStorySimpleUsage.bind({});
+FlexLayoutSimpleUsage.args = {
+  wrap: true,
+};
 
 export const ContactDetailsExample = ({ index }: { index: number }) => (
   <ContactDetails embedded={true}>
@@ -157,6 +157,9 @@ const ContactCards: ComponentStory<typeof FlexLayout> = (args) => {
   );
 };
 export const FlexLayoutComposite = ContactCards.bind({});
+FlexLayoutComposite.args = {
+  wrap: true,
+};
 
 const FlexLayoutNestedExample: ComponentStory<typeof FlexLayout> = (args) => {
   return (
@@ -179,4 +182,5 @@ export const FlexLayoutNested = FlexLayoutNestedExample.bind({});
 FlexLayoutNested.args = {
   justify: "space-between",
   gap: 6,
+  wrap: true,
 };

--- a/packages/core/stories/layout/flex-layout.stories.tsx
+++ b/packages/core/stories/layout/flex-layout.stories.tsx
@@ -34,6 +34,10 @@ export default {
       options: LAYOUT_DIRECTION,
       control: { type: "select" },
     },
+    gap: {
+      type: "number",
+      defaultValue: 3,
+    },
     justify: {
       options: FLEX_CONTENT_ALIGNMENT_BASE,
       control: { type: "select" },

--- a/packages/core/stories/layout/flex-layout.stories.tsx
+++ b/packages/core/stories/layout/flex-layout.stories.tsx
@@ -57,7 +57,7 @@ const DefaultFlexLayoutStory: ComponentStory<typeof FlexLayout> = (args) => {
   return (
     <FlexLayout {...args}>
       {Array.from({ length: 5 }, (_, index) => (
-        <FlexContent key={index} />
+        <FlexContent key={index} number={index + 1} />
       ))}
     </FlexLayout>
   );
@@ -69,7 +69,7 @@ const SeparatedItemsStory: ComponentStory<typeof FlexLayout> = (args) => {
     <FlexLayout {...args}>
       {Array.from({ length: 4 }, (_, index) => (
         <FlexItem>
-          <FlexContent key={index} />
+          <FlexContent key={index} number={index + 1} />
         </FlexItem>
       ))}
     </FlexLayout>
@@ -84,7 +84,7 @@ const Responsive: ComponentStory<typeof FlexLayout> = (args) => {
   return (
     <FlexLayout {...args}>
       {Array.from({ length: 6 }, (_, index) => (
-        <FlexContent key={index} />
+        <FlexContent key={index} number={index + 1} />
       ))}
     </FlexLayout>
   );

--- a/packages/core/stories/layout/flex-layout.stories.tsx
+++ b/packages/core/stories/layout/flex-layout.stories.tsx
@@ -4,6 +4,7 @@ import {
   FLEX_CONTENT_ALIGNMENT_BASE,
   FlexItem,
   FlexLayout,
+  LAYOUT_DIRECTION,
 } from "@jpmorganchase/uitk-core";
 import {
   Metric,
@@ -27,6 +28,10 @@ export default {
   argTypes: {
     align: {
       options: [...FLEX_ALIGNMENT_BASE, "stretch", "baseline"],
+      control: { type: "select" },
+    },
+    direction: {
+      options: LAYOUT_DIRECTION,
       control: { type: "select" },
     },
     justify: {

--- a/packages/core/stories/layout/flex-layout.stories.tsx
+++ b/packages/core/stories/layout/flex-layout.stories.tsx
@@ -94,6 +94,7 @@ const Responsive: ComponentStory<typeof FlexLayout> = (args) => {
 };
 export const ToolkitFlexLayoutResponsive = Responsive.bind({});
 ToolkitFlexLayoutResponsive.args = {
+  justify: "center",
   direction: {
     xs: "column",
     md: "row",

--- a/packages/core/stories/layout/flex-layout.stories.tsx
+++ b/packages/core/stories/layout/flex-layout.stories.tsx
@@ -37,6 +37,12 @@ export default {
       options: ["start", "center", "end", true],
       control: { type: "select" },
     },
+    wrap: {
+      control: "boolean",
+    },
+  },
+  args: {
+    wrap: true,
   },
   excludeStories: ["ContactDetailsExample", "FlexLayoutNestedExample"],
 } as ComponentMeta<typeof FlexLayout>;
@@ -51,7 +57,6 @@ const DefaultFlexLayoutStory: ComponentStory<typeof FlexLayout> = (args) => {
   );
 };
 export const DefaultFlexLayout = DefaultFlexLayoutStory.bind({});
-DefaultFlexLayout.args = {};
 
 const SeparatedItemsStory: ComponentStory<typeof FlexLayout> = (args) => {
   return (
@@ -111,9 +116,6 @@ const FlexLayoutStorySimpleUsage: ComponentStory<typeof FlexLayout> = (
   );
 };
 export const FlexLayoutSimpleUsage = FlexLayoutStorySimpleUsage.bind({});
-FlexLayoutSimpleUsage.args = {
-  wrap: true,
-};
 
 export const ContactDetailsExample = ({ index }: { index: number }) => (
   <ContactDetails embedded={true}>
@@ -145,9 +147,6 @@ const ContactCards: ComponentStory<typeof FlexLayout> = (args) => {
   );
 };
 export const FlexLayoutComposite = ContactCards.bind({});
-FlexLayoutComposite.args = {
-  wrap: true,
-};
 
 const FlexLayoutNestedExample: ComponentStory<typeof FlexLayout> = (args) => {
   return (
@@ -169,6 +168,5 @@ const FlexLayoutNestedExample: ComponentStory<typeof FlexLayout> = (args) => {
 export const FlexLayoutNested = FlexLayoutNestedExample.bind({});
 FlexLayoutNested.args = {
   justify: "space-between",
-  wrap: true,
   gap: 6,
 };

--- a/packages/core/stories/layout/flow-layout.stories.tsx
+++ b/packages/core/stories/layout/flow-layout.stories.tsx
@@ -47,7 +47,7 @@ const DefaultFlowLayoutStory: ComponentStory<typeof FlowLayout> = (args) => {
   return (
     <FlowLayout {...args}>
       {Array.from({ length: 5 }, (_, index) => (
-        <FlexContent key={index} />
+        <FlexContent key={index} number={index + 1} />
       ))}
     </FlowLayout>
   );

--- a/packages/core/stories/layout/flow-layout.stories.tsx
+++ b/packages/core/stories/layout/flow-layout.stories.tsx
@@ -31,6 +31,14 @@ export default {
       options: [...FLEX_ALIGNMENT_BASE, "stretch", "baseline"],
       control: { type: "select" },
     },
+    gap: {
+      type: "number",
+      defaultValue: 3,
+    },
+    separators: {
+      options: ["start", "center", "end", true],
+      control: { type: "select" },
+    },
   },
   excludeStories: ["MetricExample"],
 } as ComponentMeta<typeof FlowLayout>;

--- a/packages/core/stories/layout/grid-layout.stories.tsx
+++ b/packages/core/stories/layout/grid-layout.stories.tsx
@@ -20,6 +20,16 @@ export default {
   title: "Core/Layout/GridLayout",
   component: GridLayout,
   subcomponents: { GridItem },
+  argTypes: {
+    columnGap: { type: "number" },
+    columns: { type: "number", defaultValue: 12 },
+    gap: {
+      type: "number",
+      defaultValue: 3,
+    },
+    rowGap: { type: "number" },
+    rows: { type: "number", defaultValue: 1 },
+  },
 } as ComponentMeta<typeof GridLayout>;
 
 const Template: ComponentStory<typeof GridLayout> = (args) => {

--- a/packages/core/stories/layout/split-layout.stories.tsx
+++ b/packages/core/stories/layout/split-layout.stories.tsx
@@ -30,7 +30,7 @@ export default {
       options: ["start", "center", "end", true],
       control: { type: "select" },
     },
-    wrap: {
+    disableWrap: {
       type: "boolean",
     },
   },

--- a/packages/core/stories/layout/stack-layout.stories.tsx
+++ b/packages/core/stories/layout/stack-layout.stories.tsx
@@ -23,6 +23,10 @@ export default {
       options: ["start", "center", "end", true],
       control: { type: "select" },
     },
+    gap: {
+      type: "number",
+      defaultValue: 3,
+    },
   },
   excludeStories: [
     "ComplexFormOne",

--- a/packages/core/stories/layout/stack-layout.stories.tsx
+++ b/packages/core/stories/layout/stack-layout.stories.tsx
@@ -40,7 +40,7 @@ const DefaultStackLayoutStory: ComponentStory<typeof StackLayout> = (args) => {
   return (
     <StackLayout {...args}>
       {Array.from({ length: 5 }, (_, index) => (
-        <FlexContent key={index} />
+        <FlexContent key={index} number={index + 1} />
       ))}
     </StackLayout>
   );


### PR DESCRIPTION
These changes have been reviewed by Stella. They mostly include small tweaks to the storybook examples but the most important change is allowing the `FlexLayout` component to wrap by default 