### PR TITLE
Modify sideEffects to css related files for icons package.json

### DIFF
--- a/.changeset/violet-pianos-tell.md
+++ b/.changeset/violet-pianos-tell.md
@@ -2,4 +2,4 @@
 "@jpmorganchase/uitk-icons": minor
 ---
 
-Remove sideEffects false from package.json
+Modify sideEffects to css related files from package.json

--- a/.changeset/violet-pianos-tell.md
+++ b/.changeset/violet-pianos-tell.md
@@ -1,0 +1,5 @@
+---
+"@jpmorganchase/uitk-icons": minor
+---
+
+Remove sideEffects false from package.json

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -3,7 +3,6 @@
   "version": "0.2.0",
   "license": "Apache-2.0",
   "main": "src/index.ts",
-  "sideEffects": false,
   "scripts": {
     "build": "node ./scripts/generateIconComponent.js '*.svg' && node ./scripts/generateIconIndex.js"
   },

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -3,6 +3,10 @@
   "version": "0.2.0",
   "license": "Apache-2.0",
   "main": "src/index.ts",
+  "sideEffects": [
+    "**/*.css",
+    "**/*.css.js"
+  ],
   "scripts": {
     "build": "node ./scripts/generateIconComponent.js '*.svg' && node ./scripts/generateIconIndex.js"
   },


### PR DESCRIPTION
This hopefully will resolve the issue that Icon CSS is not being loaded while using `react-scripts` / webpack based setup.

        <Button>
           {"No icon here ->"}
          <SearchIcon size={12} />
        </Button>

Above code in fresh CRA / modular set up will result in below render (reproduce [repo](https://github.com/origami-z/uitk-cra-icon-css-loading))

![screenshot not icons in button](https://user-images.githubusercontent.com/5257855/179806627-885cc362-32e0-45e7-80d3-b20a8714d7f3.png)

While debugging, no code in `node_modules/@jpmorganchase/uitk-icons/dist-es/packages/icons/src/icon/Icon.css.js` is executed at runtime while using webpack based tooling (vite is fine). There might be other ways to force code being included, but given `css.js` files are generated by build tool, we don't have much control over that.

Interestingly enough, the same code doesn't have problem on Stackblitz [example](https://stackblitz.com/edit/react-ts-uarhsw?file=App.tsx), which also uses `react-scripts`.

I tested removing/editing `sideEffects` line in the sample reproduce repo's `node_modules` `package.json`, the icon is rendering fine.