### PR TITLE
fix(aria-announcer): prevent breaking full height layouts

### DIFF
--- a/.changeset/itchy-bobcats-attack.md
+++ b/.changeset/itchy-bobcats-attack.md
@@ -1,0 +1,5 @@
+---
+"@jpmorganchase/uitk-core": patch
+---
+
+prevent AriaAnnouncer breaking full height layouts

--- a/.changeset/itchy-bobcats-attack.md
+++ b/.changeset/itchy-bobcats-attack.md
@@ -2,4 +2,4 @@
 "@jpmorganchase/uitk-core": patch
 ---
 
-prevent AriaAnnouncer breaking full height layouts
+Prevent AriaAnnouncer breaking full height layouts

--- a/packages/core/src/__tests__/__e2e__/aira-announcer/AriaAnnouncer.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/aira-announcer/AriaAnnouncer.cy.tsx
@@ -1,19 +1,18 @@
 import { AriaAnnouncerProvider } from "@jpmorganchase/uitk-core";
 
-describe("Given a ToolkitProvider", () => {
-  describe("with no props set", () => {
-    it("should not affect the document flow", () => {
-      cy.mount(
-        <div id="test-1" style={{ height: "100%", width: "100%" }}>
-          <AriaAnnouncerProvider>
-            <div style={{ height: "100%", width: "100%" }} />
-          </AriaAnnouncerProvider>
-        </div>
-      );
+describe("Given a AriaAnnouncerProvider", () => {
+  it("should not affect the document flow", () => {
+    cy.mount(
+      <div id="test-1" style={{ height: "100%", width: "100%" }}>
+        <AriaAnnouncerProvider>
+          <div style={{ height: "100%", width: "100%" }} />
+        </AriaAnnouncerProvider>
+      </div>
+    );
 
-      cy.document().then((doc) => {
-        const style = doc.createElement("style");
-        style.innerHTML = `
+    cy.document().then((doc) => {
+      const style = doc.createElement("style");
+      style.innerHTML = `
                 body, html {
                     height: 100%;
                     display: block;
@@ -23,12 +22,10 @@ describe("Given a ToolkitProvider", () => {
                     height: 100%;
                 }
             `;
-        doc.head.appendChild(style);
-        const documentHeight =
-          doc.documentElement.getBoundingClientRect().height;
-        const documentScrollHeight = document.documentElement.scrollHeight;
-        expect(documentHeight).to.equal(documentScrollHeight);
-      });
+      doc.head.appendChild(style);
+      const documentHeight = doc.documentElement.getBoundingClientRect().height;
+      const documentScrollHeight = document.documentElement.scrollHeight;
+      expect(documentHeight).to.equal(documentScrollHeight);
     });
   });
 });

--- a/packages/core/src/__tests__/__e2e__/aira-announcer/AriaAnnouncer.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/aira-announcer/AriaAnnouncer.cy.tsx
@@ -1,0 +1,34 @@
+import { AriaAnnouncerProvider } from "@jpmorganchase/uitk-core";
+
+describe("Given a ToolkitProvider", () => {
+  describe("with no props set", () => {
+    it("should not affect the document flow", () => {
+      cy.mount(
+        <div id="test-1" style={{ height: "100%", width: "100%" }}>
+          <AriaAnnouncerProvider>
+            <div style={{ height: "100%", width: "100%" }} />
+          </AriaAnnouncerProvider>
+        </div>
+      );
+
+      cy.document().then((doc) => {
+        const style = doc.createElement("style");
+        style.innerHTML = `
+                body, html {
+                    height: 100%;
+                    display: block;
+                    min-height: auto;
+                }
+                [data-cy-root] {
+                    height: 100%;
+                }
+            `;
+        doc.head.appendChild(style);
+        const documentHeight =
+          doc.documentElement.getBoundingClientRect().height;
+        const documentScrollHeight = document.documentElement.scrollHeight;
+        expect(documentHeight).to.equal(documentScrollHeight);
+      });
+    });
+  });
+});

--- a/packages/core/src/aria-announcer/AriaAnnouncerProvider.tsx
+++ b/packages/core/src/aria-announcer/AriaAnnouncerProvider.tsx
@@ -74,14 +74,15 @@ export const AriaAnnouncerProvider: FC<AriaAnnouncerProviderProps> = ({
         aria-live="assertive"
         // hidden styling based on https://webaim.org/techniques/css/invisiblecontent/
         style={{
-          clip: "rect(1px, 1px, 1px, 1px)",
-          clipPath: "inset(50%)",
+          position: "absolute",
           height: 1,
           width: 1,
-          overflow: "hidden",
           padding: 0,
-          position: "absolute",
           margin: -1,
+          overflow: "hidden",
+          clip: "rect(0, 0, 0, 0)",
+          whiteSpace: "nowrap",
+          borderWidth: 0,
           ...style,
         }}
       >

--- a/packages/core/src/aria-announcer/AriaAnnouncerProvider.tsx
+++ b/packages/core/src/aria-announcer/AriaAnnouncerProvider.tsx
@@ -81,6 +81,7 @@ export const AriaAnnouncerProvider: FC<AriaAnnouncerProviderProps> = ({
           overflow: "hidden",
           padding: 0,
           position: "absolute",
+          margin: -1,
           ...style,
         }}
       >

--- a/packages/core/src/aria-announcer/AriaAnnouncerProvider.tsx
+++ b/packages/core/src/aria-announcer/AriaAnnouncerProvider.tsx
@@ -72,7 +72,7 @@ export const AriaAnnouncerProvider: FC<AriaAnnouncerProviderProps> = ({
       <div
         aria-atomic="true"
         aria-live="assertive"
-        // hidden styling based on https://webaim.org/techniques/css/invisiblecontent/
+        // hidden styling based on https://tailwindcss.com/docs/screen-readers
         style={{
           position: "absolute",
           height: 1,


### PR DESCRIPTION
Closes #277
AriaAnnouncerProvider needed a small negative margin hack to prevent affecting the document flow. Also, the styles were updated to more closely match the [tailwind visually hidden class](https://tailwindcss.com/docs/screen-readers).