### PR TITLE
fix unstable Tabs and Calendar cy test

### DIFF
--- a/packages/lab/src/__tests__/__e2e__/calendar/Calendar.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/calendar/Calendar.cy.tsx
@@ -150,7 +150,7 @@ describe("GIVEN a Calendar component", () => {
         }).should("be.visible");
       });
 
-      it("SHOULD move the focus when the shortcut keys are pressed", () => {
+      it.only("SHOULD move the focus when the shortcut keys are pressed", () => {
         cy.mount(<DefaultCalendar initialVisibleMonth={testDateDate} />);
 
         cy.findByRole("button", {
@@ -163,12 +163,12 @@ describe("GIVEN a Calendar component", () => {
 
         cy.realPress("Home");
         cy.findByRole("button", {
-          name: formatDate(testDate.startOf("week")),
+          name: formatDate(testDate.startOf("isoWeek")),
         }).should("be.focused");
 
         cy.realPress("End");
         cy.findByRole("button", {
-          name: formatDate(testDate.endOf("week")),
+          name: formatDate(testDate.endOf("isoWeek")),
         }).should("be.focused");
 
         //RESET

--- a/packages/lab/src/__tests__/__e2e__/calendar/Calendar.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/calendar/Calendar.cy.tsx
@@ -150,7 +150,7 @@ describe("GIVEN a Calendar component", () => {
         }).should("be.visible");
       });
 
-      describe.only("SHOULD move the focus when the shortcut keys are pressed", () => {
+      describe("SHOULD move the focus when the shortcut keys are pressed", () => {
         beforeEach(() => {
           cy.mount(<DefaultCalendar initialVisibleMonth={testDateDate} />);
 

--- a/packages/lab/src/__tests__/__e2e__/calendar/Calendar.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/calendar/Calendar.cy.tsx
@@ -150,55 +150,66 @@ describe("GIVEN a Calendar component", () => {
         }).should("be.visible");
       });
 
-      it.only("SHOULD move the focus when the shortcut keys are pressed", () => {
-        cy.mount(<DefaultCalendar initialVisibleMonth={testDateDate} />);
+      describe.only("SHOULD move the focus when the shortcut keys are pressed", () => {
+        beforeEach(() => {
+          cy.mount(<DefaultCalendar initialVisibleMonth={testDateDate} />);
 
-        cy.findByRole("button", {
-          name: formatDate(testDate),
-        }).focus();
+          cy.findByRole("button", {
+            name: formatDate(testDate),
+          }).focus();
 
-        cy.findByRole("button", {
-          name: formatDate(testDate),
-        }).should("be.focused");
+          cy.findByRole("button", {
+            name: formatDate(testDate),
+          }).should("be.focused");
+        });
 
-        cy.realPress("Home");
-        cy.findByRole("button", {
-          name: formatDate(testDate.startOf("isoWeek")),
-        }).should("be.focused");
+        it("HOME", () => {
+          cy.realPress("Home");
+          cy.wait(100);
+          cy.findByRole("button", {
+            name: formatDate(testDate.startOf("isoWeek")),
+          }).should("be.focused");
+        });
 
-        cy.realPress("End");
-        cy.findByRole("button", {
-          name: formatDate(testDate.endOf("isoWeek")),
-        }).should("be.focused");
+        it("END", () => {
+          cy.realPress("End");
+          cy.wait(100);
+          cy.findByRole("button", {
+            name: formatDate(testDate.endOf("isoWeek")),
+          }).should("be.focused");
+        });
 
-        //RESET
-        cy.findByRole("button", {
-          name: formatDate(testDate),
-        }).focus();
+        it("PageUp", () => {
+          cy.realPress("PageUp");
+          cy.wait(100);
+          cy.findByRole("button", {
+            name: formatDate(testDate.subtract(1, "month")),
+          }).should("be.focused");
+        });
 
-        cy.findByRole("button", {
-          name: formatDate(testDate),
-        }).should("be.focused");
+        it("PageDown", () => {
+          cy.realPress("PageDown");
+          cy.wait(100);
+          cy.findByRole("button", {
+            name: formatDate(testDate.add(1, "month")),
+          }).should("be.focused");
+        });
 
-        cy.realPress("PageUp");
-        cy.findByRole("button", {
-          name: formatDate(testDate.subtract(1, "month")),
-        }).should("be.focused");
+        it("Shift PageUp", () => {
+          cy.realPress(["Shift", "PageUp"]);
+          cy.wait(100);
+          cy.findByRole("button", {
+            name: formatDate(testDate.subtract(1, "year")),
+          }).should("be.focused");
+        });
 
-        cy.realPress("PageDown");
-        cy.findByRole("button", {
-          name: formatDate(testDate),
-        }).should("be.focused");
-
-        cy.realPress(["Shift", "PageUp"]);
-        cy.findByRole("button", {
-          name: formatDate(testDate.subtract(1, "year")),
-        }).should("be.focused");
-
-        cy.realPress(["Shift", "PageDown"]);
-        cy.findByRole("button", {
-          name: formatDate(testDate),
-        }).should("be.focused");
+        it("Shift PageDown", () => {
+          cy.realPress(["Shift", "PageDown"]);
+          cy.wait(100);
+          cy.findByRole("button", {
+            name: formatDate(testDate.add(1, "year")),
+          }).should("be.focused");
+        });
       });
     });
   });

--- a/packages/lab/src/__tests__/__e2e__/tabs/Tabs.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/tabs/Tabs.cy.tsx
@@ -245,6 +245,7 @@ describe("Editable Tabs", () => {
     it("THEN tab enters edit state", () => {
       cy.mount(<SimpleTabstrip enableRenameTab width={400} />);
       cy.get(".uitkTabstrip-inner > *:first-child").realClick();
+      cy.wait(100); // ArrowRight need some time to move focus after click
       // Navigate to second tab ...
       cy.realPress("ArrowRight");
       // First press of ENTER selects ...

--- a/packages/lab/src/__tests__/__e2e__/tabs/Tabs.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/tabs/Tabs.cy.tsx
@@ -153,6 +153,7 @@ describe("Navigation, Given a Tabstrip", () => {
           it("THEN focus will be transfered to the next tab", () => {
             cy.mount(<SimpleTabstrip width={400} />);
             cy.get(".uitkTabstrip-inner > *:first-child").realClick();
+            cy.wait(50); // ArrowRight need some time to move focus after click
             cy.realPress("ArrowRight");
             cy.get(".uitkTabstrip-inner > *:nth-child(2)")
               .should("be.focused")

--- a/packages/lab/src/__tests__/__e2e__/tabs/Tabs.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/tabs/Tabs.cy.tsx
@@ -142,6 +142,7 @@ describe("Navigation, Given a Tabstrip", () => {
             cy.get(".uitkTabstrip-inner > *:nth-child(1)").should(
               "not.be.focusVisible"
             );
+            cy.wait(100); // ArrowRight need some time to move focus after click
             cy.realPress("ArrowLeft");
             cy.get(".uitkTabstrip-inner > *:nth-child(1)").should(
               "be.focusVisible"
@@ -153,7 +154,7 @@ describe("Navigation, Given a Tabstrip", () => {
           it("THEN focus will be transfered to the next tab", () => {
             cy.mount(<SimpleTabstrip width={400} />);
             cy.get(".uitkTabstrip-inner > *:first-child").realClick();
-            cy.wait(200); // ArrowRight need some time to move focus after click
+            cy.wait(100); // ArrowRight need some time to move focus after click
             cy.realPress("ArrowRight");
             cy.get(".uitkTabstrip-inner > *:nth-child(2)")
               .should("be.focused")
@@ -407,6 +408,7 @@ describe("Adding Tabs", () => {
       it("THEN add button is included in navigation", () => {
         cy.mount(<SimpleTabstripAddRemoveTab enableAddTab width={600} />);
         cy.get(".uitkTabstrip-inner > *:nth-child(3)").realClick();
+        cy.wait(100); // ArrowRight need some time to move focus after click
         cy.realPress("ArrowRight");
         cy.realPress("ArrowRight");
         cy.realPress("ArrowRight");
@@ -683,6 +685,7 @@ describe("7) Focus management", () => {
     it("THEN Tabstrip loses focus", () => {
       cy.mount(<SimpleTabstrip enableAddTab width={600} />);
       cy.get(".uitkTabstrip-inner > *:nth-child(2)").realClick();
+      cy.wait(100); // ArrowRight need some time to move focus after click
       cy.realPress("Tab");
       cy.get('.uitkTabstrip-inner > .uitkTab[tabindex="-1"]').should(
         "have.length",

--- a/packages/lab/src/__tests__/__e2e__/tabs/Tabs.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/tabs/Tabs.cy.tsx
@@ -153,7 +153,7 @@ describe("Navigation, Given a Tabstrip", () => {
           it("THEN focus will be transfered to the next tab", () => {
             cy.mount(<SimpleTabstrip width={400} />);
             cy.get(".uitkTabstrip-inner > *:first-child").realClick();
-            cy.wait(50); // ArrowRight need some time to move focus after click
+            cy.wait(200); // ArrowRight need some time to move focus after click
             cy.realPress("ArrowRight");
             cy.get(".uitkTabstrip-inner > *:nth-child(2)")
               .should("be.focused")


### PR DESCRIPTION
We had a few instances of the test is failing on CI

>  1) Navigation, Given a Tabstrip
>        WHEN initial size is sufficient to display all contents
>          WHEN the tabstrip is first rendered
>            WHEN the selected tab is clicked
>              WHEN the right arrow key is pressed
>                THEN focus will be transfered to the next tab:
>      AssertionError: Timed out retrying after 4000ms: expected '<div#uitk-97739-1.uitkTab.uitkFocusVisible>' to be 'focused'


>   2) GIVEN a Calendar component
>        Navigation
>          Keyboard
>            SHOULD move the focus when the shortcut keys are pressed
>              Shift PageDown:
>      AssertionError: Timed out retrying after 4000ms: expected '<button.uitkCalendarDay>' to be 'focused'