### PR TITLE
Skip Calendar Unstable Tests

### DIFF
--- a/packages/lab/src/__tests__/__e2e__/calendar/Calendar.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/calendar/Calendar.cy.tsx
@@ -204,7 +204,8 @@ describe("GIVEN a Calendar component", () => {
           );
         });
 
-        it("Shift PageUp", () => {
+        // Skipping - see PR#311 for notes
+        it.skip("Shift PageUp", () => {
           cy.realPress(["Shift", "PageUp"]);
 
           cy.focused().should(
@@ -214,7 +215,8 @@ describe("GIVEN a Calendar component", () => {
           );
         });
 
-        it("Shift PageDown", () => {
+        // Skipping - see PR#311 for notes
+        it.skip("Shift PageDown", () => {
           cy.realPress(["Shift", "PageDown"]);
 
           cy.focused().should(
@@ -222,48 +224,6 @@ describe("GIVEN a Calendar component", () => {
             "aria-label",
             formatDate(testDate.add(1, "year"))
           );
-        });
-      });
-
-      describe("DEBUG shift key on CI", () => {
-        const DebugShiftKey = () => {
-          const [keys, setKeys] = React.useState<string[]>([]);
-          const handleKeyDown = (e: React.KeyboardEvent) => {
-            const newKeys = [e.key];
-            if (e.shiftKey && e.key !== "Shift") {
-              newKeys.push("Shift");
-            }
-            if (e.altKey && e.key !== "Alt") {
-              newKeys.push("Alt");
-            }
-            if (e.ctrlKey && e.key !== "Control") {
-              newKeys.push("Ctrl");
-            }
-            if (e.metaKey && e.key !== "Meta") {
-              newKeys.push("Meta");
-            }
-            setKeys(newKeys);
-          };
-          return (
-            <div>
-              <input onKeyDown={handleKeyDown} id="input" />
-              <label id="label">{keys.join(",")}</label>
-            </div>
-          );
-        };
-
-        it("Shift PageUp", () => {
-          cy.mount(<DebugShiftKey />);
-          cy.get("#input").focus().realPress(["Shift", "PageUp"]);
-
-          cy.get("#label").should("have.text", "PageUp,Shift");
-        });
-
-        it("Shift PageDown", () => {
-          cy.mount(<DebugShiftKey />);
-          cy.get("#input").focus().realPress(["Shift", "PageDown"]);
-
-          cy.get("#label").should("have.text", "PageDown,Shift");
         });
       });
     });

--- a/packages/lab/src/__tests__/__e2e__/calendar/Calendar.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/calendar/Calendar.cy.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { composeStories } from "@storybook/testing-react";
 import * as calendarStories from "@stories/calendar.stories";
 
@@ -221,6 +222,48 @@ describe("GIVEN a Calendar component", () => {
             "aria-label",
             formatDate(testDate.add(1, "year"))
           );
+        });
+      });
+
+      describe("DEBUG shift key on CI", () => {
+        const DebugShiftKey = () => {
+          const [keys, setKeys] = React.useState<string[]>([]);
+          const handleKeyDown = (e: React.KeyboardEvent) => {
+            const newKeys = [e.key];
+            if (e.shiftKey && e.key !== "Shift") {
+              newKeys.push("Shift");
+            }
+            if (e.altKey && e.key !== "Alt") {
+              newKeys.push("Alt");
+            }
+            if (e.ctrlKey && e.key !== "Control") {
+              newKeys.push("Ctrl");
+            }
+            if (e.metaKey && e.key !== "Meta") {
+              newKeys.push("Meta");
+            }
+            setKeys(newKeys);
+          };
+          return (
+            <div>
+              <input onKeyDown={handleKeyDown} id="input" />
+              <label id="label">{keys.join(",")}</label>
+            </div>
+          );
+        };
+
+        it("Shift PageUp", () => {
+          cy.mount(<DebugShiftKey />);
+          cy.get("#input").focus().realPress(["Shift", "PageUp"]);
+
+          cy.get("#label").should("have.text", "PageUp,Shift");
+        });
+
+        it("Shift PageDown", () => {
+          cy.mount(<DebugShiftKey />);
+          cy.get("#input").focus().realPress(["Shift", "PageDown"]);
+
+          cy.get("#label").should("have.text", "PageDown,Shift");
         });
       });
     });

--- a/packages/lab/src/__tests__/__e2e__/calendar/Calendar.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/calendar/Calendar.cy.tsx
@@ -165,50 +165,62 @@ describe("GIVEN a Calendar component", () => {
 
         it("HOME", () => {
           cy.realPress("Home");
-          cy.wait(100);
-          cy.findByRole("button", {
-            name: formatDate(testDate.startOf("isoWeek")),
-          }).should("be.focused");
+
+          cy.focused().should(
+            "have.attr",
+            "aria-label",
+            formatDate(testDate.startOf("isoWeek"))
+          );
         });
 
         it("END", () => {
           cy.realPress("End");
-          cy.wait(100);
-          cy.findByRole("button", {
-            name: formatDate(testDate.endOf("isoWeek")),
-          }).should("be.focused");
+
+          cy.focused().should(
+            "have.attr",
+            "aria-label",
+            formatDate(testDate.endOf("isoWeek"))
+          );
         });
 
         it("PageUp", () => {
           cy.realPress("PageUp");
-          cy.wait(100);
-          cy.findByRole("button", {
-            name: formatDate(testDate.subtract(1, "month")),
-          }).should("be.focused");
+
+          cy.focused().should(
+            "have.attr",
+            "aria-label",
+            formatDate(testDate.subtract(1, "month"))
+          );
         });
 
         it("PageDown", () => {
           cy.realPress("PageDown");
-          cy.wait(100);
-          cy.findByRole("button", {
-            name: formatDate(testDate.add(1, "month")),
-          }).should("be.focused");
+
+          cy.focused().should(
+            "have.attr",
+            "aria-label",
+            formatDate(testDate.add(1, "month"))
+          );
         });
 
         it("Shift PageUp", () => {
           cy.realPress(["Shift", "PageUp"]);
-          cy.wait(100);
-          cy.findByRole("button", {
-            name: formatDate(testDate.subtract(1, "year")),
-          }).should("be.focused");
+
+          cy.focused().should(
+            "have.attr",
+            "aria-label",
+            formatDate(testDate.subtract(1, "year"))
+          );
         });
 
         it("Shift PageDown", () => {
           cy.realPress(["Shift", "PageDown"]);
-          cy.wait(100);
-          cy.findByRole("button", {
-            name: formatDate(testDate.add(1, "year")),
-          }).should("be.focused");
+
+          cy.focused().should(
+            "have.attr",
+            "aria-label",
+            formatDate(testDate.add(1, "year"))
+          );
         });
       });
     });


### PR DESCRIPTION
`cy.focused` will automatically [retry](https://docs.cypress.io/guides/core-concepts/retry-ability) until all chained assertions have passed, according to the [doc](https://docs.cypress.io/api/commands/focused#Assertions).

I can not reproduce the problem using react 18 locally, which i guess is due to speed. Another interesting thing is that i can't get anything to `console` in calendar keydown event, by fine in other places like test or `List` code.

I also used below test code to debug, all worked fine locally and on CI.

```
describe("DEBUG shift key on CI", () => {
        const DebugShiftKey = () => {
          const [keys, setKeys] = React.useState<string[]>([]);
          const handleKeyDown = (e: React.KeyboardEvent) => {
            const newKeys = [e.key];
            if (e.shiftKey && e.key !== "Shift") {
              newKeys.push("Shift");
            }
            if (e.altKey && e.key !== "Alt") {
              newKeys.push("Alt");
            }
            if (e.ctrlKey && e.key !== "Control") {
              newKeys.push("Ctrl");
            }
            if (e.metaKey && e.key !== "Meta") {
              newKeys.push("Meta");
            }
            setKeys(newKeys);
          };
          return (
            <div>
              <input onKeyDown={handleKeyDown} id="input" />
              <label id="label">{keys.join(",")}</label>
            </div>
          );
        };

        it("Shift PageUp", () => {
          cy.mount(<DebugShiftKey />);
          cy.get("#input").focus().realPress(["Shift", "PageUp"]);

          cy.get("#label").should("have.text", "PageUp,Shift");
        });

        it("Shift PageDown", () => {
          cy.mount(<DebugShiftKey />);
          cy.get("#input").focus().realPress(["Shift", "PageDown"]);

          cy.get("#label").should("have.text", "PageDown,Shift");
        });
      });
```