### PR TITLE
Fix minor CSS typos

### DIFF
--- a/.changeset/seven-cherries-kiss.md
+++ b/.changeset/seven-cherries-kiss.md
@@ -1,0 +1,6 @@
+---
+"@jpmorganchase/uitk-core": minor
+"@jpmorganchase/uitk-lab": minor
+---
+
+Fix minor CSS typos in tokens

--- a/.changeset/seven-cherries-kiss.md
+++ b/.changeset/seven-cherries-kiss.md
@@ -3,4 +3,17 @@
 "@jpmorganchase/uitk-lab": minor
 ---
 
-Fix minor CSS typos in tokens
+Checkbox:
+-box-size -> -height and -width
+
+Pagination/Accordion:
+—pagination and —accordion prefixes added
+
+Tree node:
+—padding-left token changed to padding-left attribute: fixed typo
+
+Dialog/Toolbar:
+background-color changed to background as standard
+
+Skip link:
+—skipLink-- (double dash) changed to —skipLink-

--- a/packages/core/src/checkbox/CheckboxIcon.css
+++ b/packages/core/src/checkbox/CheckboxIcon.css
@@ -24,7 +24,8 @@
   --checkbox-borderWidth: var(--uitk-selectable-borderWidth);
   --checkbox-tick-fill: var(--uitkCheckboxIcon-tick-color, var(--uitk-selectable-primary-foreground-selected));
   --checkbox-viewbox: 14px; /* do not change, matches value in svg viewBox */
-  --checkbox-box-size: calc(var(--checkbox-viewbox) - var(--checkbox-borderWidth));
+  --checkbox-height: calc(var(--checkbox-viewbox) - var(--checkbox-borderWidth));
+  --checkbox-width: calc(var(--checkbox-viewbox) - var(--checkbox-borderWidth));
   --checkbox-box-offset: calc(var(--checkbox-borderWidth) / 2);
 
   fill: var(--uitkCheckboxIcon-solid-color, var(--uitk-selectable-background));
@@ -61,9 +62,9 @@
 
 /* Styles applied to box */
 .uitkCheckboxIcon-box {
-  height: var(--checkbox-box-size);
+  height: var(--checkbox-height);
   stroke-width: var(--checkbox-borderWidth);
-  width: var(--checkbox-box-size);
+  width: var(--checkbox-width);
   x: var(--checkbox-box-offset);
   y: var(--checkbox-box-offset);
 }

--- a/packages/lab/src/accordion/Accordion.css
+++ b/packages/lab/src/accordion/Accordion.css
@@ -17,67 +17,54 @@
 }
 
 .uitk-density-high .uitkAccordionSection {
-  --summary-padding-left: 20px;
-  --details-padding: 3px 4px 5px 20px;
+  --accordion-summary-padding-left: 20px;
+  --accordion-details-padding: 3px 4px 5px 20px;
 }
 
 .uitk-density-medium .uitkAccordionSection {
-  --summary-padding-left: 28px;
-  --details-padding: 8px 8px 9px 28px;
+  --accordion-summary-padding-left: 28px;
+  --accordion-details-padding: 8px 8px 9px 28px;
 }
 
 .uitk-density-low .uitkAccordionSection {
-  --summary-padding-left: 36px;
-  --details-padding: 12px 12px 13px 38px;
+  --accordion-summary-padding-left: 36px;
+  --accordion-details-padding: 12px 12px 13px 38px;
 }
 
 .uitk-density-touch .uitkAccordionSection {
-  --summary-padding-left: 44px;
-  --details-padding: 18px 16px 17px 44px;
+  --accordion-summary-padding-left: 44px;
+  --accordion-details-padding: 18px 16px 17px 44px;
 }
 
 .uitkAccordionSection {
-  --summary-height: var(--uitkAccordionSummary-height, var(--uitk-size-stackable));
-  --summary-fontWeight: var(--uitkAccordionSummary-fontWeight, initial);
+  --accordion-summary-height: var(--uitkAccordionSummary-height, var(--uitk-size-stackable));
+  --accordion-summary-fontWeight: var(--uitkAccordionSummary-fontWeight, initial);
 
-  --summary-background: var(--uitkAccordionSummary-background, var(--uitk-container-background-medium));
-  --summary-background-active: var(--uitkAccordionSummary-background-active, var(--uitk-container-background-medium));
-  --summary-background-disabled: var(--uitkAccordionSummary-background-disabled, var(--uitk-container-background-medium));
-  --summary-background-hover: var(--uitkAccordionSummary-background-hover, var(--uitk-actionable-primary-background-hover));
+  --accordion-summary-background: var(--uitkAccordionSummary-background, var(--uitk-container-background-medium));
+  --accordion-summary-background-active: var(--uitkAccordionSummary-background-active, var(--uitk-container-background-medium));
+  --accordion-summary-background-disabled: var(--uitkAccordionSummary-background-disabled, var(--uitk-container-background-medium));
+  --accordion-summary-background-hover: var(--uitkAccordionSummary-background-hover, var(--uitk-actionable-primary-background-hover));
 
-  --summary-text-color: var(--uitkAccordionSummary-text-color, var(--uitk-text-primary-foreground));
-  --summary-text-color-active: var(--uitkAccordionSummary-text-color-active, var(--uitk-text-primary-foreground));
-  --summary-text-color-disabled: var(--uitkAccordionSummary-text-color-disabled, var(--uitk-text-primary-foreground-disabled));
-  --summary-text-color-hover: var(--uitkAccordionSummary-text-color-hover, var(--uitk-text-primary-foreground));
+  --accordion-summary-text-color: var(--uitkAccordionSummary-text-color, var(--uitk-text-primary-foreground));
+  --accordion-summary-text-color-active: var(--uitkAccordionSummary-text-color-active, var(--uitk-text-primary-foreground));
+  --accordion-summary-text-color-disabled: var(--uitkAccordionSummary-text-color-disabled, var(--uitk-text-primary-foreground-disabled));
+  --accordion-summary-text-color-hover: var(--uitkAccordionSummary-text-color-hover, var(--uitk-text-primary-foreground));
 
-  --section-border-color: var(--uitkAccordionSection-border-color, var(--uitk-separable-secondary-borderColor));
-  --section-border-style: var(--uitkAccordionSection-border-style, var(--uitk-container-borderStyle));
-  --section-border-top-width: var(--uitkAccordionSection-border-top-width, 0);
-  --section-border-right-width: var(--uitkAccordionSection-border-right-width, 0);
-  --section-border-bottom-width: var(--uitkAccordionSection-border-bottom-width, 1px);
-  --section-border-left-width: var(--uitkAccordionSection-border-left-width, 0);
+  --accordion-summary-focus-outline-style: var(--uitk-focused-outlineStyle);
+  --accordion-summary-focus-outline-width: var(--uitk-focused-outlineWidth);
+  --accordion-summary-focus-outline-color: var(--uitk-focused-outlineColor);
+  --accordion-summary-focus-outline-offset: var(--uitk-focused-outlineOffset);
 
-  --section-margin-top: var(--uitkAccordionSection-margin-top, 0);
-  --section-margin-right: var(--uitkAccordionSection-margin-right, 0);
-  --section-margin-bottom: var(--uitkAccordionSection-margin-bottom, 0);
-  --section-margin-left: var(--uitkAccordionSection-margin-left, 0);
-
-  --summary-focus-outline-style: var(--uitk-focused-outlineStyle);
-  --summary-focus-outline-width: var(--uitk-focused-outlineWidth);
-  --summary-focus-outline-color: var(--uitk-focused-outlineColor);
-  --summary-focus-outline-offset: var(--uitk-focused-outlineOffset);
-
-  --summary-icon-transition-default: transform 150ms cubic-bezier(0.4, 0, 0.2, 1);
-  --summary-icon-transform: var(--uitkAccordionSummary-icon-expand-transform, rotate(90deg));
-  --summary-icon-transition: var(--uitkAccordionSummary-icon-transition, var(--summary-icon-transition-default));
+  --accordion-summary-icon-transition-default: transform 150ms cubic-bezier(0.4, 0, 0.2, 1);
+  --accordion-summary-icon-transform: var(--uitkAccordionSummary-icon-expand-transform, rotate(90deg));
+  --accordion-summary-icon-transition: var(--uitkAccordionSummary-icon-transition, var(--accordion-summary-icon-transition-default));
 }
 
 .uitkAccordionSection {
-  border-color: var(--section-border-color);
-  border-style: solid;
-  --border-width: var(--section-border-top-width) var(--section-border-right-width) var(--section-border-bottom-width) var(--section-border-left-width);
-  border-width: var(--uitkAccordionSection-border-width, var(--border-width));
-  margin: var(--section-margin-top) var(--section-margin-right) var(--section-margin-bottom) var(--section-margin-left);
+  border-color: var(--uitkAccordionSection-border-color, var(--uitk-separable-secondary-borderColor));
+  border-style: var(--uitkAccordionSection-border-style, var(--uitk-container-borderStyle));
+  border-width: var(--uitkAccordionSection-border-width, 0 0 1px 0);
+  margin: var(--uitkAccordionSection-margin, 0);
   position: relative;
 }
 
@@ -92,38 +79,38 @@
 }
 
 .uitkAccordionSummary {
-  height: var(--summary-height);
-  line-height: var(--summary-height);
-  font-weight: var(--summary-fontWeight);
-  background: var(--summary-background);
-  color: var(--summary-text-color);
+  height: var(--accordion-summary-height);
+  line-height: var(--accordion-summary-height);
+  font-weight: var(--accordion-summary-fontWeight);
+  background: var(--accordion-summary-background);
+  color: var(--accordion-summary-text-color);
   font-size: var(--uitkAccordionSummary-font-size, var(--uitk-text-fontSize));
   font-family: var(--uitkAccordionSummary-font-family, var(--uitk-text-fontFamily));
-  padding-left: var(--summary-padding-left);
+  padding-left: var(--accordion-summary-padding-left);
   position: relative;
 }
 
 .uitkAccordionSummary:focus-visible {
-  outline-style: var(--summary-focus-outline-style);
-  outline-width: var(--summary-focus-outline-width);
-  outline-color: var(--summary-focus-outline-color);
-  outline-offset: var(--summary-focus-outline-offset);
+  outline-style: var(--accordion-summary-focus-outline-style);
+  outline-width: var(--accordion-summary-focus-outline-width);
+  outline-color: var(--accordion-summary-focus-outline-color);
+  outline-offset: var(--accordion-summary-focus-outline-offset);
 }
 
 .uitkAccordionSummary:hover:not(.uitkAccordionSummary-disabled) {
-  background: var(--summary-background-hover);
-  color: var(--summary-text-color-hover);
+  background: var(--accordion-summary-background-hover);
+  color: var(--accordion-summary-text-color-hover);
   cursor: pointer;
 }
 
 .uitkAccordionSummary-expanded {
-  background: var(--summary-background-active);
-  color: var(--summary-text-color-active);
+  background: var(--accordion-summary-background-active);
+  color: var(--accordion-summary-text-color-active);
 }
 
 .uitkAccordionSummary-disabled {
-  background: var(--summary-background-disabled);
-  color: var(--summary-text-color-disabled);
+  background: var(--accordion-summary-background-disabled);
+  color: var(--accordion-summary-text-color-disabled);
 }
 
 .uitkAccordionSummary-icon {
@@ -131,16 +118,16 @@
   top: 0;
   bottom: 0;
   left: 0;
-  width: var(--summary-padding-left);
+  width: var(--accordion-summary-padding-left);
   display: flex;
   flex-direction: row;
   justify-content: center;
   align-items: center;
-  transition: var(--summary-icon-transition);
+  transition: var(--accordion-summary-icon-transition);
 }
 
 .uitkAccordionSummary-expanded .uitkAccordionSummary-icon {
-  transform: var(--summary-icon-transform);
+  transform: var(--accordion-summary-icon-transform);
 }
 
 .uitkAccordionDetails {
@@ -149,7 +136,7 @@
 }
 
 .uitkAccordionDetails-content {
-  padding: var(--uitkAccordionDetails-padding, var(--details-padding));
+  padding: var(--uitkAccordionDetails-padding, var(--accordion-details-padding));
 }
 
 .uitkAccordionDetails-disabled {

--- a/packages/lab/src/dialog/Dialog.css
+++ b/packages/lab/src/dialog/Dialog.css
@@ -1,5 +1,5 @@
 .uitkDialog {
-  --dialog-background-color: var(--uitkDialog-background-color, var(--uitk-container-background-medium));
+  --dialog-background: var(--uitkDialog-background, var(--uitk-container-background-medium));
   --dialog-border-bottom-width: var(--uitkDialog-border-bottom-width, 2px);
   --dialog-border-color: var(--uitkDialog-border-color, var(--uitk-container-borderColor-medium));
   --dialog-border-style: var(--uitkDialog-border-style, var(--uitk-container-borderStyle));
@@ -10,7 +10,7 @@
 }
 
 .uitkDialog {
-  background: var(--dialog-background-color);
+  background: var(--dialog-background);
   border-color: var(--dialog-border-color);
   border-width: var(--dialog-border-width);
   border-style: var(--dialog-border-style);

--- a/packages/lab/src/pagination/Pagination.css
+++ b/packages/lab/src/pagination/Pagination.css
@@ -1,21 +1,21 @@
 .uitk-density-medium .uitkPagination {
-  --button-size: 28px;
-  --font-size: 12px;
+  --pagination-button-size: 28px;
+  --pagination-fontSize: 12px;
 }
 
 .uitk-density-high .uitkPagination {
-  --button-size: 20px;
-  --font-size: 11px;
+  --pagination-button-size: 20px;
+  --pagination-fontSize: 11px;
 }
 
 .uitk-density-low .uitkPagination {
-  --button-size: 36px;
-  --font-size: 14px;
+  --pagination-button-size: 36px;
+  --pagination-fontSize: 14px;
 }
 
 .uitk-density-touch .uitkPagination {
-  --button-size: 44px;
-  --font-size: 16px;
+  --pagination-button-size: 44px;
+  --pagination-fontSize: 16px;
 }
 
 .uitkPagination {
@@ -24,8 +24,8 @@
 }
 
 .uitkPagination-arrowButton {
-  width: var(--button-size);
-  height: var(--button-size);
+  width: var(--pagination-button-size);
+  height: var(--pagination-button-size);
 }
 
 .uitkPagination-previousButton {
@@ -37,8 +37,8 @@
 }
 
 .uitkPagination-pageButton {
-  min-width: var(--button-size);
-  height: var(--button-size);
+  min-width: var(--pagination-button-size);
+  height: var(--pagination-button-size);
   --uitkButton-font-weight: var(--uitk-text-fontWeight);
 }
 
@@ -52,8 +52,8 @@
 }
 
 .uitkPagination-ellipsis {
-  width: var(--button-size);
-  height: var(--button-size);
+  width: var(--pagination-button-size);
+  height: var(--pagination-button-size);
   text-align: center;
 }
 
@@ -72,21 +72,21 @@
 }
 
 .uitkPagination-compactInput {
-  height: var(--button-size);
+  height: var(--pagination-button-size);
   min-width: unset;
 }
 
 .uitkPagination-compactInputFixed {
-  min-width: var(--button-size);
-  width: var(--button-size);
+  min-width: var(--pagination-button-size);
+  width: var(--pagination-button-size);
 }
 
 .uitkPagination-compactSeparator {
-  height: var(--button-size);
-  width: var(--button-size);
+  height: var(--pagination-button-size);
+  width: var(--pagination-button-size);
   text-align: center;
-  font-size: var(--font-size);
-  line-height: var(--button-size);
+  font-size: var(--pagination-fontSize);
+  line-height: var(--pagination-button-size);
 }
 
 .uitkPagination-goToInputWrapper {
@@ -105,11 +105,11 @@
 }
 
 .uitkPagination-goToInput {
-  height: var(--button-size);
+  height: var(--pagination-button-size);
   min-width: unset;
 }
 
 .uitkPagination-goToInputFixed {
-  min-width: var(--button-size);
-  width: var(--button-size);
+  min-width: var(--pagination-button-size);
+  width: var(--pagination-button-size);
 }

--- a/packages/lab/src/skip-link/SkipLink.css
+++ b/packages/lab/src/skip-link/SkipLink.css
@@ -1,8 +1,8 @@
 /* CSS Variables for the Skip Link */
 .uitkSkipLink {
-  --skiplink-padding: var(--uitkSkipLink-padding, var(--uitk-size-unit));
-  --skiplink-margin: var(--uitkSkipLink-margin, var(--uitk-size-unit));
-  --skiplink-background: var(--uitkSkipLink-background, var(--uitk-actionable-primary-background));
+  --skipLink-padding: var(--uitkSkipLink-padding, var(--uitk-size-unit));
+  --skipLink-margin: var(--uitkSkipLink-margin, var(--uitk-size-unit));
+  --skipLink-background: var(--uitkSkipLink-background, var(--uitk-actionable-primary-background));
   --skipLink-color: var(--uitkSkipLink-color, var(--uitk-text-primary-foreground));
 }
 
@@ -33,9 +33,9 @@
   width: auto;
   height: auto;
   white-space: nowrap;
-  margin: var(--skiplink-margin);
-  padding: calc(var(--skiplink-padding) - 1px) var(--skiplink-padding) var(--skiplink-padding);
-  background: var(--skiplink-background);
+  margin: var(--skipLink-margin);
+  padding: calc(var(--skipLink-padding) - 1px) var(--skipLink-padding) var(--skipLink-padding);
+  background: var(--skipLink-background);
   color: var(--skipLink-color);
   box-shadow: var(--uitk-overlayable-shadow-popout);
 }

--- a/packages/lab/src/skip-link/SkipLink.css
+++ b/packages/lab/src/skip-link/SkipLink.css
@@ -1,8 +1,8 @@
 /* CSS Variables for the Skip Link */
 .uitkSkipLink {
-  --skipLink--padding: var(--uitkSkipLink-padding, var(--uitk-size-unit));
-  --skipLink--margin: var(--uitkSkipLink-margin, var(--uitk-size-unit));
-  --skipLink--background: var(--uitkSkipLink-background, var(--uitk-actionable-primary-background));
+  --skiplink-padding: var(--uitkSkipLink-padding, var(--uitk-size-unit));
+  --skiplink-margin: var(--uitkSkipLink-margin, var(--uitk-size-unit));
+  --skiplink-background: var(--uitkSkipLink-background, var(--uitk-actionable-primary-background));
   --skipLink-color: var(--uitkSkipLink-color, var(--uitk-text-primary-foreground));
 }
 
@@ -33,9 +33,9 @@
   width: auto;
   height: auto;
   white-space: nowrap;
-  margin: var(--skipLink--margin);
-  padding: calc(var(--skipLink--padding) - 1px) var(--skipLink--padding) var(--skipLink--padding);
-  background: var(--skipLink--background);
+  margin: var(--skiplink-margin);
+  padding: calc(var(--skiplink-padding) - 1px) var(--skiplink-padding) var(--skiplink-padding);
+  background: var(--skiplink-background);
   color: var(--skipLink-color);
   box-shadow: var(--uitk-overlayable-shadow-popout);
 }

--- a/packages/lab/src/toolbar/Toolbar.css
+++ b/packages/lab/src/toolbar/Toolbar.css
@@ -7,7 +7,7 @@
 .uitkToolbar {
   --toolbar-size: calc(var(--uitk-size-base) + var(--uitk-size-unit) * 2);
 
-  background-color: var(--uitkToolbar-background-color, var(--toolbar-background));
+  background: var(--uitkToolbar-background, var(--toolbar-background));
   box-sizing: border-box;
   font-size: var(--toolbar-font-size);
   justify-content: flex-start;

--- a/packages/lab/src/tree/TreeNode.css
+++ b/packages/lab/src/tree/TreeNode.css
@@ -83,11 +83,11 @@
 }
 
 .uitkTreeNode:not([aria-expanded]) {
-  --padding-left: calc(var(--tree-node-padding-left) + var(--tree-toggle-width) + var(--tree-node-indent));
+  padding-left: calc(var(--tree-node-padding-left) + var(--tree-toggle-width) + var(--tree-node-indent));
 }
 
 .uitkTreeNode[aria-expanded] > .uitkTreeNode-label {
-  --padding-left: calc(var(--tree-node-padding-left) + var(--tree-toggle-width) + var(--tree-node-indent));
+  padding-left: calc(var(--tree-node-padding-left) + var(--tree-toggle-width) + var(--tree-node-indent));
 }
 
 .uitkTreeNode[aria-expanded] {


### PR DESCRIPTION
Checkbox:
-box-size -> -height and -width

Pagination/Accordion:
—pagination and —accordion prefixes added

Tree node:
—padding-left token changed to padding-left attribute: fixed typo

Dialog/Toolbar:
background-color changed to background as standard 

Skip link:
—skipLink-- (double dash) changed to —skipLink-