### PR TITLE
Refactor scrim props

### DIFF
--- a/packages/core/src/__tests__/__e2e__/scrim/Scrim.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/scrim/Scrim.cy.tsx
@@ -193,6 +193,32 @@ describe("Given a Scrim", () => {
     });
   });
 
+  describe("WHEN disableReturnFocus is true", () => {
+    it("THEN should NOT return focus to the last focused element before", () => {
+      function TestComponent() {
+        const [open, setOpen] = useState(false);
+        return (
+          <>
+            <Scrim open={open} disableReturnFocus>
+              <button onClick={() => setOpen((old) => !old)}>
+                CLOSE SCRIM
+              </button>
+            </Scrim>
+            <button onClick={() => setOpen((old) => !old)}>OPEN SCRIM</button>
+          </>
+        );
+      }
+      cy.mount(<TestComponent />);
+
+      cy.findByRole("button", { name: "OPEN SCRIM" }).click();
+      cy.findByRole("button", { name: "CLOSE SCRIM" })
+        .should("have.focus")
+        .realClick();
+      cy.wait(50);
+      cy.findByRole("button", { name: "OPEN SCRIM" }).should("not.have.focus");
+    });
+  });
+
   describe("WHEN in a container state", () => {
     it("THEN should prevent selection to siblings and niblings", () => {
       function TestComponent() {

--- a/packages/core/src/__tests__/__e2e__/scrim/Scrim.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/scrim/Scrim.cy.tsx
@@ -131,7 +131,7 @@ describe("Given a Scrim", () => {
         const [open, setOpen] = useState(false);
         return (
           <div ref={parentRef}>
-            <Scrim containerFix open={open} parentRef={parentRef}>
+            <Scrim open={open} containerRef={parentRef}>
               <button onClick={() => setOpen((old) => !old)}>
                 CLOSE SCRIM
               </button>
@@ -175,7 +175,7 @@ describe("Given a Scrim", () => {
         const [open, setOpen] = useState(false);
         return (
           <div data-testid="parent" ref={parentRef}>
-            <Scrim containerFix open={open} parentRef={parentRef}>
+            <Scrim open={open} containerRef={parentRef}>
               <button onClick={() => setOpen((old) => !old)}>
                 CLOSE SCRIM
               </button>
@@ -193,10 +193,21 @@ describe("Given a Scrim", () => {
     });
 
     it("THEN should have `aria-modal=false` and `role=dialog`", () => {
-      cy.mount(<Scrim containerFix open />);
+      function TestComponent() {
+        const parentRef = useRef<HTMLDivElement>(null);
+        return (
+          <div data-testid="parent" ref={parentRef}>
+            <Scrim open containerRef={parentRef}>
+              <button>button</button>
+            </Scrim>
+          </div>
+        );
+      }
+      cy.mount(<TestComponent />);
       cy.findByRole("dialog")
         .should("exist")
-        .and("have.attr", "aria-modal", "false");
+        .and("have.attr", "aria-modal", "false")
+        .and("have.attr", "role", "dialog");
     });
   });
 

--- a/packages/core/src/__tests__/__e2e__/scrim/Scrim.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/scrim/Scrim.cy.tsx
@@ -168,6 +168,31 @@ describe("Given a Scrim", () => {
     });
   });
 
+  describe("WHEN disableFocusTrap is true", () => {
+    it("THEN should allow focus to leave the focus trap", () => {
+      function TestComponent() {
+        const [open, setOpen] = useState(false);
+        return (
+          <>
+            <Scrim open={open} disableFocusTrap>
+              <button onClick={() => setOpen((old) => !old)}>
+                CLOSE SCRIM
+              </button>
+            </Scrim>
+            <button onClick={() => setOpen((old) => !old)}>OPEN SCRIM</button>
+          </>
+        );
+      }
+      cy.mount(<TestComponent />);
+
+      cy.findByRole("button", { name: "OPEN SCRIM" }).click();
+      cy.findByRole("button", { name: "CLOSE SCRIM" }).should("have.focus");
+      cy.findByRole("button", { name: "CLOSE SCRIM" }).realPress("Tab");
+      // findByRole doesn't work here because FocusManager puts aria-hidden on all the elements outside its scope
+      cy.contains("button", "OPEN SCRIM").should("have.focus");
+    });
+  });
+
   describe("WHEN in a container state", () => {
     it("THEN should prevent selection to siblings and niblings", () => {
       function TestComponent() {

--- a/packages/core/src/focus-manager/FocusManager.tsx
+++ b/packages/core/src/focus-manager/FocusManager.tsx
@@ -28,7 +28,7 @@ export interface FocusManagerProps {
   children?: ReactNode;
   className?: string;
   disableAutoFocus?: boolean;
-  disableEnforceFocus?: boolean;
+  disableFocusTrap?: boolean;
   disableReturnFocus?: boolean;
   fallbackFocusRef?: RefObject<HTMLElement>;
   tabEnabledSelectors?: string;
@@ -63,7 +63,7 @@ export function FocusManager(props: FocusManagerProps): JSX.Element {
     children,
     className,
     disableAutoFocus,
-    disableEnforceFocus,
+    disableFocusTrap,
     disableReturnFocus,
     fallbackFocusRef,
     tabEnabledSelectors = defaultSelector,
@@ -195,7 +195,7 @@ export function FocusManager(props: FocusManagerProps): JSX.Element {
     fallbackFocusRef,
   ]);
 
-  const enforceFocus = active && !disableEnforceFocus;
+  const enforceFocus = active && !disableFocusTrap;
 
   return (
     <div

--- a/packages/core/src/focus-manager/FocusManager.tsx
+++ b/packages/core/src/focus-manager/FocusManager.tsx
@@ -32,7 +32,7 @@ export interface FocusManagerProps {
   disableReturnFocus?: boolean;
   fallbackFocusRef?: RefObject<HTMLElement>;
   tabEnabledSelectors?: string;
-  returnFocus?: UseReturnFocusProps["focusOptions"];
+  returnFocusOptions?: UseReturnFocusProps["focusOptions"];
 }
 
 function tryFocus(node?: HTMLElement) {
@@ -67,7 +67,7 @@ export function FocusManager(props: FocusManagerProps): JSX.Element {
     disableReturnFocus,
     fallbackFocusRef,
     tabEnabledSelectors = defaultSelector,
-    returnFocus,
+    returnFocusOptions,
   } = props;
 
   const containerRef = useRef<HTMLDivElement>(null);
@@ -77,7 +77,7 @@ export function FocusManager(props: FocusManagerProps): JSX.Element {
   const [hasFocus, setHasFocus] = useState(false);
 
   useReturnFocus({
-    focusOptions: returnFocus,
+    focusOptions: returnFocusOptions,
     disabled: disableReturnFocus || disableAutoFocus,
     active,
     document: ownerDocument(containerRef.current),

--- a/packages/core/src/focus-manager/internal/useReturnFocus.ts
+++ b/packages/core/src/focus-manager/internal/useReturnFocus.ts
@@ -19,7 +19,7 @@ export interface UseReturnFocusProps {
   active?: boolean;
   disabled?: boolean;
   document: DocumentOrShadowRoot;
-  focusOptions?: FocusOptions | boolean;
+  focusOptions?: FocusOptions;
 }
 
 export function useReturnFocus({

--- a/packages/core/src/scrim/Scrim.tsx
+++ b/packages/core/src/scrim/Scrim.tsx
@@ -67,7 +67,7 @@ export interface ScrimProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * If `true`, the trap focus will not prevent focus from leaving the trap focus while open.
    */
-  disableEnforceFocus?: boolean;
+  disableFocusTrap?: boolean;
   /**
    * If `true`, the trap focus will not restore focus to previously focused element once
    * trap focus is hidden.
@@ -118,7 +118,7 @@ export const Scrim = forwardRef<HTMLDivElement, ScrimProps>(function Scrim(
     className,
     children,
     disableAutoFocus,
-    disableEnforceFocus,
+    disableFocusTrap,
     disableReturnFocus,
     fallbackFocusRef,
     onBackDropClick,
@@ -229,7 +229,7 @@ export const Scrim = forwardRef<HTMLDivElement, ScrimProps>(function Scrim(
         active={open}
         autoFocusRef={autoFocusRef}
         disableAutoFocus={disableAutoFocus}
-        disableEnforceFocus={disableEnforceFocus || !!containerRef?.current}
+        disableFocusTrap={disableFocusTrap || !!containerRef?.current}
         disableReturnFocus={disableReturnFocus}
         returnFocus={returnFocus}
         tabEnabledSelectors={tabEnabledSelectors}

--- a/packages/core/src/scrim/Scrim.tsx
+++ b/packages/core/src/scrim/Scrim.tsx
@@ -18,14 +18,15 @@ import "./Scrim.css";
 
 const scrims = new Set();
 
-const defaultParent = typeof document !== "undefined" ? document.body : null;
+const defaultParent = () =>
+  typeof document !== "undefined" ? document.body : null;
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = () => {};
 
 const withBaseName = makePrefixer("uitkScrim");
 
-function preventSelection(parent = defaultParent): () => void {
+function preventSelection(parent = defaultParent()): () => void {
   if (parent) {
     const previous = parent.style.userSelect;
     parent.style.userSelect = "none";

--- a/packages/core/src/scrim/Scrim.tsx
+++ b/packages/core/src/scrim/Scrim.tsx
@@ -97,10 +97,9 @@ export interface ScrimProps extends HTMLAttributes<HTMLDivElement> {
    */
   containerRef?: RefObject<HTMLElement>;
   /**
-   * Prop to return focus to active element of when Scrim is closed.
-   * The default value is true.
+   * Options object to pass to the `focus()` method that is called on the previously focused element when Scrim is closed.
    */
-  returnFocus?: FocusManagerProps["returnFocus"];
+  returnFocusOptions?: FocusManagerProps["returnFocusOptions"];
   /**
    * comma separated string of query selectors which may need to be overridden for edge cases.
    */
@@ -125,7 +124,7 @@ export const Scrim = forwardRef<HTMLDivElement, ScrimProps>(function Scrim(
     onClose,
     open,
     containerRef,
-    returnFocus = true,
+    returnFocusOptions,
     tabEnabledSelectors = defaultSelector,
     zIndex,
     ...rest
@@ -231,7 +230,7 @@ export const Scrim = forwardRef<HTMLDivElement, ScrimProps>(function Scrim(
         disableAutoFocus={disableAutoFocus}
         disableFocusTrap={disableFocusTrap || !!containerRef?.current}
         disableReturnFocus={disableReturnFocus}
-        returnFocus={returnFocus}
+        returnFocusOptions={returnFocusOptions}
         tabEnabledSelectors={tabEnabledSelectors}
       >
         <ScrimContext.Provider value={onClose}>

--- a/packages/core/stories/scrim.doc.stories.mdx
+++ b/packages/core/stories/scrim.doc.stories.mdx
@@ -1,7 +1,6 @@
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
 import { ComponentAnatomy } from "docs/components/ComponentAnatomy";
 import { ToolkitProvider, Scrim } from "@jpmorganchase/uitk-core";
-import { withFlexGap } from "docs/decorators/withFlexGap";
 import {
   CSSClassTable,
   CSSVariableTable,

--- a/packages/core/stories/scrim.stories.tsx
+++ b/packages/core/stories/scrim.stories.tsx
@@ -146,10 +146,9 @@ export const ScrimContainer: ComponentStory<typeof Scrim> = () => {
       <Scrim
         aria-label="Example Scrim"
         closeWithEscape
-        containerFix
         onClose={handleClose}
         open={open}
-        parentRef={parentRef}
+        containerRef={parentRef}
         className="uitkEmphasisLow"
         zIndex={2}
       >

--- a/packages/core/stories/scrim.stories.tsx
+++ b/packages/core/stories/scrim.stories.tsx
@@ -19,7 +19,7 @@ export const DefaultScrim: ComponentStory<typeof Scrim> = () => {
   return (
     <>
       <Button onClick={handleRequestOpen}>click to open scrim</Button>
-      <Scrim aria-label="Example Scrim" open={open} returnFocus>
+      <Scrim aria-label="Example Scrim" open={open}>
         <Button onClick={handleClose}>CLOSE SCRIM</Button>
       </Scrim>
     </>


### PR DESCRIPTION
Closes #331 

## Overview
Each prop refactor is split in to its own commit so I can cherry pick what we like on to the #338 or merge this whole PR if we like them all.

## Changes
- Refactor `containerFix` and `parentRef` in to a single prop. Currently both of these props are necessary for the "container" feature to work. One is a feature flag to enable it and the ref is necessary to know which container element to bound Scrim to. The refactor consolidates both of these in to a single prop `containerRef` which is used both as a ref and as a feature flag. The only downside of this approach that I can see is that the container mode cannot be switched to on the fly. You have to close and then reopen the Scrim to bind it to a container element. You cannot toggle an already open Scrim from being bound to the window, to being bound to an element. 
- Rename `disableEnforceFocus` -> `disableFocusTrap` This is just a preference of mine since I feel like focus trap is an established term for this functionality but that might not be a good enough reason to make a breaking change.
- Rename `returnFocus` -> `returnFocusOptions`. This one on the other hand I feel more strongly about. I initially thought this was a boolean flag (it was typed as such, and used in one place as such) to toggle the returning of focus on and off but when I followed the code it turns out it is just an object that is passed to the `focus()` method as the options for focusing an element. We have a different prop for returning focus toggle. I removed the type as well because I couldn't find a documentation about a boolean option for the focus method anywhere. I assume it is some very old legacy api.