### PR TITLE
Change checkbox token -solid-color to -fill

### DIFF
--- a/.changeset/honest-cats-yell.md
+++ b/.changeset/honest-cats-yell.md
@@ -1,0 +1,6 @@
+---
+"@jpmorganchase/uitk-core": minor
+"@jpmorganchase/uitk-grid": minor
+---
+
+Change checkbox -solid-color token to -fill

--- a/packages/core/src/checkbox/CheckboxIcon.css
+++ b/packages/core/src/checkbox/CheckboxIcon.css
@@ -28,7 +28,7 @@
   --checkbox-width: calc(var(--checkbox-viewbox) - var(--checkbox-borderWidth));
   --checkbox-box-offset: calc(var(--checkbox-borderWidth) / 2);
 
-  fill: var(--uitkCheckboxIcon-solid-color, var(--uitk-selectable-background));
+  fill: var(--uitkCheckboxIcon-fill, var(--uitk-selectable-background));
   height: var(--uitkCheckboxIcon-size, var(--checkbox-size));
   stroke: var(--uitkCheckboxIcon-stroke, var(--uitk-selectable-borderColor));
   stroke-width: var(--uitkCheckboxIcon-strokeWidth, var(--uitk-selectable-borderWidth));
@@ -52,12 +52,12 @@
 .uitkCheckboxIcon-checked {
   --checkbox-borderWidth: var(--uitkCheckboxIcon-borderWidth-checked, 0px);
 
-  fill: var(--uitkCheckboxIcon-solid-color-checked, var(--uitk-selectable-borderColor-selected));
+  fill: var(--uitkCheckboxIcon-fill-checked, var(--uitk-selectable-borderColor-selected));
 }
 
 /* Styles applied if `checked={true}` and `disabled={true}` */
 .uitkCheckboxIcon-checked.uitkCheckboxIcon-disabled {
-  fill: var(--uitkCheckboxIcon-solid-color-disabled, var(--uitk-selectable-borderColor-selectedDisabled));
+  fill: var(--uitkCheckboxIcon-fill-disabled, var(--uitk-selectable-borderColor-selectedDisabled));
 }
 
 /* Styles applied to box */

--- a/packages/core/src/pill/internal/PillCheckbox.css
+++ b/packages/core/src/pill/internal/PillCheckbox.css
@@ -7,8 +7,8 @@
 
   --uitkCheckboxIcon-stroke: var(--uitk-selectable-borderColor);
   --uitkCheckboxIcon-stroke-hover: var(--uitk-selectable-borderColor);
-  --uitkCheckboxIcon-solid-color: none;
-  --uitkCheckboxIcon-solid-color-checked: none;
+  --uitkCheckboxIcon-fill: none;
+  --uitkCheckboxIcon-fill-checked: none;
   --uitkCheckboxIcon-borderWidth-checked: var(--uitk-selectable-borderWidth);
   --uitkCheckboxIcon-tick-color: var(--uitk-taggable-foreground);
 }

--- a/packages/core/stories/Checkbox.stories.new-app-checkbox.css
+++ b/packages/core/stories/Checkbox.stories.new-app-checkbox.css
@@ -1,5 +1,5 @@
 .uitk-light.uitk-newapp,
 .uitk-dark.uitk-newapp {
   --uitkCheckboxIcon-tick-fill: var(--uitk-color-purple-40);
-  --uitkCheckboxIcon-solid-color-checked: var(--uitk-color-purple-300);
+  --uitkCheckboxIcon-fill-checked: var(--uitk-color-purple-300);
 }

--- a/packages/core/stories/checkbox.doc.stories.mdx
+++ b/packages/core/stories/checkbox.doc.stories.mdx
@@ -130,6 +130,6 @@ The CSS is as simple as below:
 .uitk-light.uitk-newapp,
 .uitk-dark.uitk-newapp {
   --uitkCheckboxIcon-tick-fill: var(--uitk-color-purple-40);
-  --uitkCheckboxIcon-solid-color-checked: var(--uitk-color-purple-300);
+  --uitkCheckboxIcon-fill-checked: var(--uitk-color-purple-300);
 }
 ```

--- a/packages/grid/src/grid/column-types/row-selection-checkbox/RowSelectionCheckboxColumn.css
+++ b/packages/grid/src/grid/column-types/row-selection-checkbox/RowSelectionCheckboxColumn.css
@@ -1,27 +1,27 @@
 .uitk-light .uitkGridRowSelectionCheckboxCellValue {
   --checkbox-outline-color: var(--uitk-color-grey-90);
-  --checkbox-solid-color: var(--uitk-color-blue-500);
+  --checkbox-fill: var(--uitk-color-blue-500);
   --checkbox-outline-color-hover: var(--uitk-color-blue-400);
   --checkbox-tick-color: var(--uitk-color-white);
 }
 
 .uitk-dark .uitkGridRowSelectionCheckboxCellValue {
   --checkbox-outline-color: var(--uitk-color-grey-100);
-  --checkbox-solid-color: var(--uitk-color-blue-400);
+  --checkbox-fill: var(--uitk-color-blue-400);
   --checkbox-outline-color-hover: var(--uitk-color-blue-300);
   --checkbox-tick-color: var(--uitk-color-grey-800);
 }
 
 .uitk-light .uitkGridRowSelectionCheckboxHeaderValue {
   --checkbox-outline-color: var(--uitk-color-grey-90);
-  --checkbox-solid-color: var(--uitk-color-blue-500);
+  --checkbox-fill: var(--uitk-color-blue-500);
   --checkbox-outline-color-hover: var(--uitk-color-blue-400);
   --checkbox-tick-color: var(--uitk-color-white);
 }
 
 .uitk-dark .uitkGridRowSelectionCheckboxHeaderValue {
   --checkbox-outline-color: var(--uitk-color-grey-100);
-  --checkbox-solid-color: var(--uitk-color-blue-400);
+  --checkbox-fill: var(--uitk-color-blue-400);
   --checkbox-outline-color-hover: var(--uitk-color-blue-300);
   --checkbox-tick-color: var(--uitk-color-grey-800);
 }
@@ -42,7 +42,7 @@
   height: var(--checkbox-size);
   width: var(--checkbox-size);
   stroke: var(--checkbox-outline-color);
-  fill: var(--checkbox-solid-color);
+  fill: var(--checkbox-fill);
 }
 
 .uitkGridRowSelectionCheckboxCellValue-checkedIcon-tick {
@@ -73,7 +73,7 @@
   width: var(--checkbox-size);
   overflow: visible;
   stroke: var(--checkbox-outline-color);
-  fill: var(--checkbox-solid-color);
+  fill: var(--checkbox-fill);
 }
 
 .uitkGridRowSelectionCheckboxHeaderValue-checkedIcon-tick {


### PR DESCRIPTION
Change checkbox token -solid-color to -fill since it is used for fill, and solid-color is picked up as a CSS attr on #344 linting