### PR TITLE
Fix z-index for ComboBox, Dropdown and LayerLayout due to CSS variable name mismatch

### DIFF
--- a/.changeset/thirty-kings-do.md
+++ b/.changeset/thirty-kings-do.md
@@ -1,0 +1,5 @@
+---
+"@jpmorganchase/uitk-lab": patch
+---
+
+Fix z-index for ComboBox, Dropdown and LayerLayout due to CSS variable name mismatch

--- a/packages/lab/src/combo-box-deprecated/ComboBox.css
+++ b/packages/lab/src/combo-box-deprecated/ComboBox.css
@@ -9,5 +9,5 @@
 }
 
 .uitkComboBox-listWindowRoot {
-  z-index: calc(var(--uitk-zindex-tooltip) - 1);
+  z-index: calc(var(--uitk-zIndex-tooltip) - 1);
 }

--- a/packages/lab/src/dropdown/Dropdown.css
+++ b/packages/lab/src/dropdown/Dropdown.css
@@ -13,5 +13,5 @@
 
 .uitkDropdown-popup {
   background: var(--uitk-container-background-medium);
-  z-index: calc(var(--uitk-zindex-tooltip) - 1);
+  z-index: calc(var(--uitk-zIndex-tooltip) - 1);
 }

--- a/packages/lab/src/layout/LayerLayout/LayerLayout.css
+++ b/packages/lab/src/layout/LayerLayout/LayerLayout.css
@@ -21,7 +21,7 @@
   overflow: auto;
   padding: var(--layerLayout-padding);
   box-shadow: var(--uitkLayerLayout-boxShadow, var(--layerLayout-boxShadow));
-  z-index: calc(var(--uitk-zindex-appheader) - 1);
+  z-index: calc(var(--uitk-zIndex-appheader) - 1);
 }
 
 .uitkLayerLayout-fullScreen {


### PR DESCRIPTION
z-index bug 

![dropdown z-index bug](https://user-images.githubusercontent.com/5257855/186478872-6ef39e2d-717e-4fcb-a7d9-d315002abe30.png)


https://uitk.pages.dev/?path=/story/lab-dropdown--with-form-field-label-top