### PR TITLE
Fix Button justify-content css

### DIFF
--- a/.changeset/unlucky-colts-destroy.md
+++ b/.changeset/unlucky-colts-destroy.md
@@ -1,0 +1,5 @@
+---
+"@jpmorganchase/uitk-core": patch
+---
+
+Fix Button `justify-content` invalid css value

--- a/packages/core/src/button/Button.css
+++ b/packages/core/src/button/Button.css
@@ -108,7 +108,7 @@
   color: var(--uitkButton-text-color, var(--button-text-color));
   cursor: var(--uitkButton-cursor, pointer);
   display: inline-block;
-  justify-content: (--uitkButton-justifyContent, center);
+  justify-content: var(--uitkButton-justifyContent, center);
   font-size: var(--uitkButton-fontSize, var(--uitk-text-fontSize));
   font-family: var(--uitkButton-fontFamily, var(--uitk-text-fontFamily));
   line-height: var(--uitkButton-lineHeight, var(--uitk-text-base-lineHeight));


### PR DESCRIPTION
`justify-content` value is invalid without `var`

So text will not be center aligned

![button left aligned text](https://user-images.githubusercontent.com/5257855/186489144-f72f1b84-37bb-4e08-b02d-deea20bb6da9.png)
