### PR TITLE
Fix Dropdown button active text and icon color

### DIFF
--- a/.changeset/grumpy-socks-develop.md
+++ b/.changeset/grumpy-socks-develop.md
@@ -1,0 +1,5 @@
+---
+"@jpmorganchase/uitk-lab": patch
+---
+
+Fix Dropdown button active text and icon color

--- a/packages/lab/src/dropdown/DropdownBase.tsx
+++ b/packages/lab/src/dropdown/DropdownBase.tsx
@@ -97,7 +97,6 @@ export const DropdownBase = forwardRef<HTMLDivElement, DropdownBaseProps>(
           shift({ limiter: limitShift() }),
           size({
             apply({ availableHeight }) {
-              console.log({ availableHeight });
               setMaxPopupHeight(availableHeight);
             },
           }),

--- a/packages/lab/src/dropdown/DropdownButton.css
+++ b/packages/lab/src/dropdown/DropdownButton.css
@@ -13,7 +13,8 @@
 }
 
 .uitkDropdownButton:active {
-  --uitkIcon-color: var(--uitk-actionable-secondary-text-color);
+  --uitkIcon-color: var(--uitk-actionable-secondary-foreground);
+  --uitkButton-text-color-active: var(--uitk-actionable-secondary-foreground);
 }
 
 .uitkDropdownButton-fullwidth {


### PR DESCRIPTION
Dropdown text will be invisible in `:active` state 

![dropdown active color](https://user-images.githubusercontent.com/5257855/186490949-2fb0c6b4-cc7d-4501-bf8b-11b7100962e1.png)

https://d9ff6dec.uitk.pages.dev/?path=/story/lab-dropdown--with-form-field-label-top