### PR TITLE
Fix: Bug in getCharacteristicValue

### DIFF
--- a/.changeset/small-starfishes-battle.md
+++ b/.changeset/small-starfishes-battle.md
@@ -1,0 +1,5 @@
+---
+"@jpmorganchase/uitk-core": patch
+---
+
+Fix theme getCharacteristicValue function.

--- a/packages/core/src/theme/Theme.ts
+++ b/packages/core/src/theme/Theme.ts
@@ -37,7 +37,7 @@ export class Theme {
   ): string | null {
     const cssVariableName = `--uitk-${characteristicName}-${variant}`;
     const scopeTarget =
-      scopeElement || document.body.querySelector(`.uitk-${this.id}`);
+      scopeElement || document.body.querySelector(`.uitk-${this.name}`);
     if (scopeTarget) {
       const style = getComputedStyle(scopeTarget);
       const variableValue = style.getPropertyValue(cssVariableName);


### PR DESCRIPTION
The theme's `id` is for example `uitk-dark` whereas the theme's `name` is just `dark`. 

By using `.uitk-${this.id}`, the `uitk-` portion was duplicated and the code would try to run ``document.body.querySelector(`.uitk-uitk-dark`)`` for example.

This change simply changes the `id` to `name` in that code snippet, alternatively, replacing `.uitk-${this.id}` with `${this.id}` would also suffice if that makes more sense.

While this is not fixed, you can instead call `getCharacteristicValue()` with the `scopeElement` parameter set to ``document.body.querySelector(`.uitk-${theme.name}`)``.