### PR TITLE
Export list common hooks type SelectHandler, ScrollingAPI

### DIFF
--- a/.changeset/small-buttons-cover.md
+++ b/.changeset/small-buttons-cover.md
@@ -1,0 +1,5 @@
+---
+"@jpmorganchase/uitk-lab": patch
+---
+
+Export `SelectHandler` and `ScrollingAPI` for List

--- a/packages/lab/src/index.ts
+++ b/packages/lab/src/index.ts
@@ -1,6 +1,8 @@
 import {
   SelectionChangeHandler,
+  SelectHandler,
   SelectionStrategy,
+  ScrollingAPI,
   useCollectionItems,
 } from "./common-hooks";
 
@@ -64,5 +66,7 @@ export type {
   ListChangeHandlerDeprecated,
   ListSelectHandlerDeprecated,
   SelectionChangeHandler,
+  SelectHandler,
+  ScrollingAPI,
   SelectionStrategy,
 };


### PR DESCRIPTION
Without the type, it's very tedious to type `onSelect` handler like below

```
const handleSelect: ListProps<Item, "default">["onSelect"] = (_, item) => { ... };

<List onSelect={handleSelect} ... />
```