### PR TITLE
List: omit `defaultValue` HTML attribute to avoid confusion

### DIFF
--- a/.changeset/lemon-suits-dream.md
+++ b/.changeset/lemon-suits-dream.md
@@ -1,0 +1,5 @@
+---
+"@jpmorganchase/uitk-lab": minor
+---
+
+List: omit `defaultValue` HTML attribute to avoid confusion

--- a/packages/lab/src/list/listTypes.ts
+++ b/packages/lab/src/list/listTypes.ts
@@ -56,7 +56,7 @@ export interface ListProps<
   Item = string,
   Selection extends SelectionStrategy = "default"
 > extends SelectionProps<Item, Selection>,
-    Omit<HTMLAttributes<HTMLDivElement>, "onSelect"> {
+    Omit<HTMLAttributes<HTMLDivElement>, "onSelect" | "defaultValue"> {
   /**
    * The component used to render a ListItem instead of the default. This must itself render a ListItem,
    * must implement props that extend ListItemProps and must forward ListItem props to the ListItem.


### PR DESCRIPTION
`defaultValue` can be autocompleted from `HTMLAttributes<HTMLDivElement>` when using `List`, `Dropdown` etc. It won't do anything without reading the doc that the correct intend is using `defaultSelected` and `selected` for uncontrolled/controlled pairs