### PR TITLE
Remove component name classes when tokens are density dependent

### DIFF
--- a/.changeset/orange-emus-turn.md
+++ b/.changeset/orange-emus-turn.md
@@ -1,0 +1,7 @@
+---
+"@jpmorganchase/uitk-core": minor
+"@jpmorganchase/uitk-grid": minor
+"@jpmorganchase/uitk-lab": minor
+---
+
+Fix for class names in selectors causing nesting issues when design tokens are density specific

--- a/packages/core/src/control-label/ControlLabel.css
+++ b/packages/core/src/control-label/ControlLabel.css
@@ -26,37 +26,44 @@
   color: var(--uitkControlLabel-color-disabled, var(--uitk-text-primary-foreground-disabled));
 }
 
-.uitk-density-medium .uitkControlLabel-labelRight {
-  margin-left: 6px;
-  margin-right: 0px;
+.uitk-density-medium {
+  --controlLabel-right-marginLeft: 6px;
+  --controlLabel-right-marginRight: 0px;
 }
-.uitk-density-high .uitkControlLabel-labelRight {
-  margin-left: 3px;
-  margin-right: 0px;
+.uitk-density-high {
+  --controlLabel-right-marginLeft: 3px;
+  --controlLabel-right-marginRight: 0px;
 }
-.uitk-density-low .uitkControlLabel-labelRight {
-  margin-left: 9px;
-  margin-right: 0px;
+.uitk-density-low {
+  --controlLabel-right-marginLeft: 9px;
+  --controlLabel-right-marginRight: 0px;
 }
-.uitk-density-touch .uitkControlLabel-labelRight {
-  margin-left: 12px;
-  margin-right: 0px;
+.uitk-density-touch {
+  --controlLabel-right-marginLeft: 12px;
+  --controlLabel-right-marginRight: 0px;
 }
 
-/* Backwards compatable styling for TK1 */
-.uitk-density-medium .backwardsCompat .uitkControlLabel-label {
-  margin-right: 6px;
+.uitkControlLabel-labelRight {
+  margin-left: var(--uitkControlLabel-right-marginLeft, var(--controlLabel-right-marginLeft));
+  margin-right: var(--uitkControlLabel-right-marginRight, var(--controlLabel-right-marginRight));
 }
-.uitk-density-high .backwardsCompat .uitkControlLabel-label {
-  margin-right: 4px;
+
+/* TK1 backwards compatible styling */
+
+.uitk-density-medium {
+  --backwardsCompat-controlLabel-marginRight: 6px;
 }
-.uitk-density-low .backwardsCompat .uitkControlLabel-label {
-  margin-right: 9px;
+.uitk-density-high {
+  --backwardsCompat-controlLabel-marginRight: 4px;
 }
-.uitk-density-touch .backwardsCompat .uitkControlLabel-label {
-  margin-right: 12px;
+.uitk-density-low {
+  --backwardsCompat-controlLabel-marginRight: 9px;
+}
+.uitk-density-touch {
+  --backwardsCompat-controlLabel-marginRight: 12px;
 }
 
 .backwardsCompat .uitkControlLabel-label {
-  line-height: 1.3;
+  line-height: var(--uitk-text-base-lineHeight);
+  margin-right: var(--backwardsCompat-controlLabel-marginRight);
 }

--- a/packages/core/src/input/Input.css
+++ b/packages/core/src/input/Input.css
@@ -1,14 +1,14 @@
 /* Styles applied to the root element dependent on density */
-.uitk-density-touch .uitkInput {
+.uitk-density-touch {
   --input-button-inset: 4px;
 }
-.uitk-density-low .uitkInput {
+.uitk-density-low {
   --input-button-inset: 4px;
 }
-.uitk-density-medium .uitkInput {
+.uitk-density-medium {
   --input-button-inset: 2px;
 }
-.uitk-density-high .uitkInput {
+.uitk-density-high {
   --input-button-inset: 2px;
 }
 

--- a/packages/core/stories/switch.qa.stories.tsx
+++ b/packages/core/stories/switch.qa.stories.tsx
@@ -18,10 +18,10 @@ export const AllExamplesGrid: Story<
   const { className } = props;
   return (
     <QAContainer cols={4} {...props}>
-      <Switch label="Default" />
-      <Switch checked label="Default" />
-      <Switch disabled label="Default" />
-      <Switch checked disabled label="Default" />
+      <Switch className={className} label="Default" />
+      <Switch className={className} checked label="Default" />
+      <Switch className={className} disabled label="Default" />
+      <Switch className={className} checked disabled label="Default" />
     </QAContainer>
   );
 };
@@ -41,6 +41,9 @@ BackwardsCompatGrid.parameters = {
 
 export const CompareWithOriginalToolkit: Story = () => {
   return (
-    <BackwardsCompatGrid imgSrc="/visual-regression-screenshots/Switch-vr-snapshot.png" />
+    <BackwardsCompatGrid
+      className="backwardsCompat"
+      imgSrc="/visual-regression-screenshots/Switch-vr-snapshot.png"
+    />
   );
 };

--- a/packages/grid/src/grid/column-types/row-selection-radio/RowSelectionRadioColumn.css
+++ b/packages/grid/src/grid/column-types/row-selection-radio/RowSelectionRadioColumn.css
@@ -6,27 +6,27 @@
   justify-content: center;
 }
 
-.uitk-density-medium .uitkGridRowSelectionRadioHeaderValue {
-  --radio-size: 14px;
+.uitk-density-medium {
+  --grid-rowSelection-radio-size: 14px;
 }
 
-.uitk-density-high .uitkGridRowSelectionRadioHeaderValue {
-  --radio-size: 12px;
+.uitk-density-high {
+  --grid-rowSelection-radio-size: 12px;
 }
 
-.uitk-density-ultrahigh .uitkGridRowSelectionRadioHeaderValue {
-  --radio-size: 12px;
+.uitk-density-ultrahigh {
+  --grid-rowSelection-radio-size: 12px;
 }
 
-.uitk-density-low .uitkGridRowSelectionRadioHeaderValue {
-  --radio-size: 16px;
+.uitk-density-low {
+  --grid-rowSelection-radio-size: 16px;
 }
 
-.uitk-density-touch .uitkGridRowSelectionRadioHeaderValue {
-  --radio-size: 18px;
+.uitk-density-touch {
+  --grid-rowSelection-radio-size: 18px;
 }
 
 .uitkGridRowSelectionRadioHeaderValue {
   height: var(--uitkGrid-rowHeight);
-  width: var(--radio-size);
+  width: var(--grid-rowSelection-radio-size);
 }

--- a/packages/grid/src/grid/components/Grid.css
+++ b/packages/grid/src/grid/components/Grid.css
@@ -1,28 +1,28 @@
-.uitk-density-touch .uitkGrid {
+.uitk-density-touch {
   --uitkGrid-rowHeight: 60px;
   --uitkGrid-padding: 16px;
   --uitkGrid-fontSize: 16px;
 }
 
-.uitk-density-low .uitkGrid {
+.uitk-density-low {
   --uitkGrid-rowHeight: 48px;
   --uitkGrid-padding: 12px;
   --uitkGrid-fontSize: 14px;
 }
 
-.uitk-density-medium .uitkGrid {
+.uitk-density-medium {
   --uitkGrid-rowHeight: 36px;
   --uitkGrid-padding: 8px;
   --uitkGrid-fontSize: 12px;
 }
 
-.uitk-density-high .uitkGrid {
+.uitk-density-high {
   --uitkGrid-rowHeight: 24px;
   --uitkGrid-padding: 8px;
   --uitkGrid-fontSize: 12px;
 }
 
-.uitk-density-ultrahigh .uitkGrid {
+.uitk-density-ultrahigh {
   --uitkGrid-rowHeight: 20px;
   --uitkGrid-padding: 4px;
   --uitkGrid-fontSize: 12px;
@@ -157,39 +157,40 @@
   --uitk-zIndex-tooltip: 1500;
 }
 
-/*ControlLabel*/
-.uitk-density-ultrahigh .uitkGrid .uitkControlLabel-labelRight {
-  margin-left: 3px;
-  margin-right: 0;
-}
-.uitk-density-ultrahigh .uitkGrid .backwardCompat .uitkControlLabel-label {
-  margin-right: 4px;
-}
+.uitk-density-ultrahigh {
+  --grid-controlLabel-right-marginLeft: 3px;
+  --grid-controlLabel-right-marginRight: 0;
 
-/*Input*/
-.uitk-density-ultrahigh .uitkGrid .uitkInput {
-  --input-button-inset: 2px;
-}
+  --grid-input-button-inset: 2px;
 
-/*Tooltip*/
-.uitk-density-ultrahigh .uitkGrid .uitkTooltip {
-  --icon-top: 1px;
-}
+  --grid-tooltip-icon-top: 1px;
+  --grid-tokenizedInput-gutter-size: calc(var(--uitk-size-basis-unit) - 1px);
+  --grid-tokenizedInput-pill-group-y-padding: calc(var(--uitk-size-unit) / 2 + 1px);
+  --grid-tokenizedInput-last-pill-margin: var(--uitk-size-unit);
 
-/*TokenizedInput*/
-.uitk-density-ultrahigh .uitkGrid .uitkTokenizedInput {
-  --tokenized-input-gutter-size: calc(var(--uitk-size-basis-unit) - 1px);
-  --tokenized-input-pill-group-y-padding: calc(var(--uitk-size-unit) / 2 + 1px);
-  --tokenized-input-last-pill-margin: var(--uitk-size-unit);
-}
-/*ToggleButton*/
-.uitk-density-ultrahigh .uitkGrid .uitkToggleButton {
-  --toggleButton-icon-padding: 1px;
+  --grid-toggleButton-icon-padding: 1px;
+
+  --backwardsCompat-controlLabel-right-marginRight: 4px;
 }
 
 .uitkGrid {
   --uitkGrid-scrollBar-size: 15px;
   --uitkGrid-cell-padding: 0 var(--uitkGrid-padding) 0 var(--uitkGrid-padding);
+
+  /* --grid- tokens below only defined for ultrahigh density, otherwise use default */
+  --uitkControlLabel-right-marginLeft: var(--grid-controlLabel-right-marginLeft, var(--controlLabel-right-marginLeft));
+  --uitkControlLabel-right-marginRight: var(--grid-controlLabel-right-marginRight, var(--controlLabel-right-marginRight));
+  --uitkInput-button-inset: var(--grid-input-button-inset, var(--input-button-inset));
+  --uitkToggleButton-icon-padding: var(--grid-toggleButton-icon-padding, var(--toggleButton-icon-padding));
+  --uitkTokenizedInput-gutter-size: var(--grid-tokenizedInput-gutter-size, var(--tokenizedInput-gutter-size));
+  --uitkTokenizedInput-pill-group-y-padding: var(--grid-tokenizedInput-pill-group-y-padding, var(--tokenizedInput-pill-group-y-padding));
+  --uitkTokenizedInput-last-pill-margin: var(--grid-tokenizedInput-last-pill-margin, var(--tokenizedInput-last-pill-margin));
+  --uitkTooltip-icon-top: var(--grid-tooltip-icon-top, var(--tooltip-icon-top));
+}
+
+.uitkGrid.backwardsCompat {
+  /* --backwardsCompat token only defined for ultrahigh density, otherwise use default */
+  --uitkControlLabel-right-marginRight: var(--backwardsCompat-controlLabel-right-marginRight, var(--controlLabel-right-marginRight));
 }
 
 .uitk-light .uitkGrid {

--- a/packages/lab/src/accordion/Accordion.css
+++ b/packages/lab/src/accordion/Accordion.css
@@ -16,22 +16,22 @@
   border-radius: var(--accordion-borderRadius);
 }
 
-.uitk-density-high .uitkAccordionSection {
+.uitk-density-high {
   --accordion-summary-paddingLeft: 20px;
   --accordion-details-padding: 3px 4px 5px 20px;
 }
 
-.uitk-density-medium .uitkAccordionSection {
+.uitk-density-medium {
   --accordion-summary-paddingLeft: 28px;
   --accordion-details-padding: 8px 8px 9px 28px;
 }
 
-.uitk-density-low .uitkAccordionSection {
+.uitk-density-low {
   --accordion-summary-paddingLeft: 36px;
   --accordion-details-padding: 12px 12px 13px 38px;
 }
 
-.uitk-density-touch .uitkAccordionSection {
+.uitk-density-touch {
   --accordion-summary-paddingLeft: 44px;
   --accordion-details-padding: 18px 16px 17px 44px;
 }

--- a/packages/lab/src/breadcrumbs/Breadcrumbs.css
+++ b/packages/lab/src/breadcrumbs/Breadcrumbs.css
@@ -21,7 +21,7 @@
   flex-wrap: wrap;
 }
 
-/* --- backwards compatible --- */
+/* TK1 Backwards compatibility */
 
 .backwardsCompat.uitkBreadcrumbs .uitkBreadcrumbs-ol {
   gap: 0;
@@ -32,15 +32,20 @@
 .backwardsCompat.uitkBreadcrumbs .uitkBreadcrumbs-li {
   padding: 2px;
 }
-.uitk-density-medium .backwardsCompat.uitkBreadcrumbs .uitkBreadcrumbs-ol li {
-  margin-right: 6px;
+
+.uitk-density-medium {
+  --backwardsCompat-breadcrumbs-ol-li-marginRight: 6px;
 }
-.uitk-density-high .backwardsCompat.uitkBreadcrumbs .uitkBreadcrumbs-ol li {
-  margin-right: 2px;
+.uitk-density-high {
+  --backwardsCompat-breadcrumbs-ol-li-marginRight: 2px;
 }
-.uitk-density-low .backwardsCompat.uitkBreadcrumbs .uitkBreadcrumbs-ol li {
-  margin-right: 10px;
+.uitk-density-low {
+  --backwardsCompat-breadcrumbs-ol-li-marginRight: 10px;
 }
-.uitk-density-touch .backwardsCompat.uitkBreadcrumbs .uitkBreadcrumbs-ol li {
-  margin-right: 14px;
+.uitk-density-touch {
+  --backwardsCompat-breadcrumbs-ol-li-marginRight: 14px;
+}
+
+.backwardsCompat.uitkBreadcrumbs .uitkBreadcrumbs-ol li {
+  margin-right: var(--backwardsCompat-breadcrumbs-ol-li-marginRight);
 }

--- a/packages/lab/src/calendar/internal/CalendarDay.css
+++ b/packages/lab/src/calendar/internal/CalendarDay.css
@@ -136,19 +136,19 @@
   text-decoration: line-through;
 }
 
-.uitk-density-high .uitkCalendarDay-blockedIcon {
+.uitk-density-high {
   --calendar-day-blocked-icon-size: 14px;
 }
 
-.uitk-density-medium .uitkCalendarDay-blockedIcon {
+.uitk-density-medium {
   --calendar-day-blocked-icon-size: 18px;
 }
 
-.uitk-density-low .uitkCalendarDay-blockedIcon {
+.uitk-density-low {
   --calendar-day-blocked-icon-size: 24px;
 }
 
-.uitk-density-touch .uitkCalendarDay-blockedIcon {
+.uitk-density-touch {
   --calendar-day-blocked-icon-size: 28px;
 }
 

--- a/packages/lab/src/calendar/internal/CalendarNavigation.css
+++ b/packages/lab/src/calendar/internal/CalendarNavigation.css
@@ -1,8 +1,10 @@
-.uitkCalendarNavigation {
+.uitk-density-medium,
+.uitk-density-touch,
+.uitk-density-low {
   --calendar-navigation-gap: calc(var(--uitk-size-unit) * 0.5);
 }
 
-.uitk-density-high .uitkCalendarNavigation {
+.uitk-density-high {
   --calendar-navigation-gap: 0px;
 }
 

--- a/packages/lab/src/color-chooser/ColorChooser.css
+++ b/packages/lab/src/color-chooser/ColorChooser.css
@@ -3,10 +3,6 @@
   height: calc(2 * var(--uitk-size-unit));
   width: calc(2 * var(--uitk-size-unit));
 }
-.uitk-density-high .uitkColorChooser-overlayButtonSwatch {
-  height: calc(3 * var(--uitk-size-unit));
-  width: calc(3 * var(--uitk-size-unit));
-}
 
 .uitkColorChooser-overlayButtonSwatchWithBorder {
   border: 0.2px solid var(--uitk-editable-borderColor);

--- a/packages/lab/src/contact-details/ContactDetails.css
+++ b/packages/lab/src/contact-details/ContactDetails.css
@@ -274,30 +274,48 @@
   width: var(--contactDetails-icon-size);
 }
 
-/* TODO: backwards compat shouldn't be bound directly to density */
-.uitk-density-touch .backwardsCompat.uitkContactDetails-default .uitkContactPrimaryInfo {
-  font-size: 30px;
+/* TK1 Backwards compatibility */
+
+.uitk-density-touch {
+  --backwardsCompat-contactDetails-h2-fontSize: 30px;
+  --backwardsCompat-contactDetails-h4-fontSize: 14px;
+  --backwardsCompat-contactDetails-default-toggle-marginRight: calc(var(--uitk-size-unit) * 0.65);
+  --backwardsCompat-contactDetails-default-toggle-marginTop: calc(var(--uitk-size-unit) * 0.4);
 }
-.uitk-density-touch .backwardsCompat.uitkContactDetails-compact .uitkContactSecondaryInfo,
-.uitk-density-touch .backwardsCompat.uitkContactDetails-compact .uitkContactTertiaryInfo,
-.uitk-density-touch .backwardsCompat.uitkContactDetails-mini .uitkContactSecondaryInfo {
-  font-size: 14px;
+
+.uitk-density-high,
+.uitk-density-low,
+.uitk-density-medium {
+  --backwardsCompat-contactDetails-default-toggle-marginRight: var(--uitk-size-unit);
+  --backwardsCompat-contactDetails-default-toggle-marginTop: calc(var(--uitk-size-unit) * 0.5);
+  /* Value doesn't change for these densities, defined to avoid nesting issues */
+  --backwardsCompat-contactDetails-h4-fontSize: var(--uitk-text-h4-fontSize);
+  /* This value is ideally handled by the Text component anyway, but re-defined to avoid nesting issues */
+  --backwardsCompat-contactDetails-h2-fontSize: var(--backwardsCompat-text-h2-fontSize);
 }
+
+.backwardsCompat.uitkContactDetails-default .uitkContactPrimaryInfo {
+  font-size: var(--backwardsCompat-contactDetails-h2-fontSize);
+}
+
+.backwardsCompat.uitkContactDetails-compact .uitkContactSecondaryInfo,
+.backwardsCompat.uitkContactDetails-compact .uitkContactTertiaryInfo,
+.backwardsCompat.uitkContactDetails-mini .uitkContactSecondaryInfo {
+  font-size: var(--backwardsCompat-contactDetails-h4-fontSize);
+}
+
 .backwardsCompat.uitkContactDetails-compact .uitkContactTertiaryInfo {
   margin-left: 16px;
 }
+
 .backwardsCompat.uitkContactDetails-mini .uitkContactSecondaryInfo,
 .backwardsCompat.uitkContactDetails-mini-stacked .uitkContactSecondaryInfo {
   margin-left: var(--uitk-size-unit);
 }
 
 .backwardsCompat.uitkContactDetails-default .uitkContactFavoriteToggle {
-  margin-right: var(--uitk-size-unit);
-  margin-top: calc(var(--uitk-size-unit) * 0.5);
-}
-.uitk-density-touch .backwardsCompat.uitkContactDetails-default .uitkContactFavoriteToggle {
-  margin-right: calc(var(--uitk-size-unit) * 0.65);
-  margin-top: calc(var(--uitk-size-unit) * 0.4);
+  margin-right: var(--backwardsCompat-contactDetails-default-toggle-marginRight);
+  margin-top: var(--backwardsCompat-contactDetails-default-toggle-marginTop);
 }
 
 .backwardsCompat.uitkContactDetails .uitkContactFavoriteToggle-deselected,

--- a/packages/lab/src/dialog/DialogTitle.css
+++ b/packages/lab/src/dialog/DialogTitle.css
@@ -1,16 +1,16 @@
-.uitk-density-touch .uitkDialogTitle {
+.uitk-density-touch {
   --dialog-title-fontSize: 26px;
 }
 
-.uitk-density-low .uitkDialogTitle {
+.uitk-density-low {
   --dialog-title-fontSize: 24px;
 }
 
-.uitk-density-medium .uitkDialogTitle {
+.uitk-density-medium {
   --dialog-title-fontSize: 22px;
 }
 
-.uitk-density-high .uitkDialogTitle {
+.uitk-density-high {
   --dialog-title-fontSize: 20px;
 }
 

--- a/packages/lab/src/metric/MetricContent.css
+++ b/packages/lab/src/metric/MetricContent.css
@@ -38,129 +38,99 @@
   text-align: right;
 }
 
+/* TK1 Backwards compatibility */
+
+.uitk-density-high {
+  --backwardsCompat-metric-horizontal-small-subvalue-marginTop: -2px;
+  --backwardsCompat-metric-horizontal-medium-subvalue-marginTop: -5px;
+  --backwardsCompat-metric-horizontal-large-subvalue-marginTop: -11px;
+
+  --backwardsCompat-metric-vertical-small-value-container-marginTop: 1px;
+  --backwardsCompat-metric-vertical-small-subvalue-marginTop: 2px;
+  --backwardsCompat-metric-vertical-medium-value-container-marginTop: 1px;
+  --backwardsCompat-metric-vertical-medium-subvalue-marginTop: 2px;
+  --backwardsCompat-metric-vertical-large-value-container-marginTop: 1px;
+  --backwardsCompat-metric-vertical-large-subvalue-marginTop: 1px;
+}
+.uitk-density-medium {
+  --backwardsCompat-metric-horizontal-small-subvalue-marginTop: -1px;
+  --backwardsCompat-metric-horizontal-medium-subvalue-marginTop: -4px;
+  --backwardsCompat-metric-horizontal-large-subvalue-marginTop: -10px;
+
+  --backwardsCompat-metric-vertical-small-value-container-marginTop: 2px;
+  --backwardsCompat-metric-vertical-small-subvalue-marginTop: 2px;
+  --backwardsCompat-metric-vertical-medium-value-container-marginTop: 2px;
+  --backwardsCompat-metric-vertical-medium-subvalue-marginTop: 2px;
+  --backwardsCompat-metric-vertical-large-value-container-marginTop: 2px;
+  --backwardsCompat-metric-vertical-large-subvalue-marginTop: 2px;
+}
+.uitk-density-low {
+  --backwardsCompat-metric-horizontal-small-subvalue-marginTop: 0px;
+  --backwardsCompat-metric-horizontal-medium-subvalue-marginTop: -3px;
+  --backwardsCompat-metric-horizontal-large-subvalue-marginTop: -9px;
+
+  --backwardsCompat-metric-vertical-small-value-container-marginTop: 3px;
+  --backwardsCompat-metric-vertical-small-subvalue-marginTop: 3px;
+  --backwardsCompat-metric-vertical-medium-value-container-marginTop: 3px;
+  --backwardsCompat-metric-vertical-medium-subvalue-marginTop: 3px;
+  --backwardsCompat-metric-vertical-large-value-container-marginTop: 3px;
+  --backwardsCompat-metric-vertical-large-subvalue-marginTop: 3px;
+}
+.uitk-density-touch {
+  --backwardsCompat-metric-horizontal-small-subvalue-marginTop: 1px;
+  --backwardsCompat-metric-horizontal-medium-subvalue-marginTop: -2px;
+  --backwardsCompat-metric-horizontal-large-subvalue-marginTop: -8px;
+
+  --backwardsCompat-metric-vertical-small-value-container-marginTop: 4px;
+  --backwardsCompat-metric-vertical-small-subvalue-marginTop: 4px;
+  --backwardsCompat-metric-vertical-medium-value-container-marginTop: 4px;
+  --backwardsCompat-metric-vertical-medium-subvalue-marginTop: 4px;
+  --backwardsCompat-metric-vertical-large-value-container-marginTop: 4px;
+  --backwardsCompat-metric-vertical-large-subvalue-marginTop: 4px;
+}
+
 /* HORIZONTAL */
 
 /* Size small */
-.uitk-density-medium .backwardsCompat.uitkMetric.uitkMetric-orientation-horizontal.uitkMetric-size-small .uitkMetricContent-subvalue {
-  margin-top: -1px;
-}
-.uitk-density-high .backwardsCompat.uitkMetric.uitkMetric-orientation-horizontal.uitkMetric-size-small .uitkMetricContent-subvalue {
-  margin-top: -2px;
-}
-.uitk-density-low .backwardsCompat.uitkMetric.uitkMetric-orientation-horizontal.uitkMetric-size-small .uitkMetricContent-subvalue {
-  margin-top: 0px;
-}
-.uitk-density-touch .backwardsCompat.uitkMetric.uitkMetric-orientation-horizontal.uitkMetric-size-small .uitkMetricContent-subvalue {
-  margin-top: 1px;
+.backwardsCompat.uitkMetric.uitkMetric-orientation-horizontal.uitkMetric-size-small .uitkMetricContent-subvalue {
+  margin-top: var(--backwardsCompat-metric-horizontal-small-subvalue-marginTop);
 }
 
 /* Size medium */
-.uitk-density-medium .backwardsCompat.uitkMetric.uitkMetric-orientation-horizontal.uitkMetric-size-medium .uitkMetricContent-subvalue {
-  margin-top: -4px;
-}
-.uitk-density-high .backwardsCompat.uitkMetric.uitkMetric-orientation-horizontal.uitkMetric-size-medium .uitkMetricContent-subvalue {
-  margin-top: -5px;
-}
-.uitk-density-low .backwardsCompat.uitkMetric.uitkMetric-orientation-horizontal.uitkMetric-size-medium .uitkMetricContent-subvalue {
-  margin-top: -3px;
-}
-.uitk-density-touch .backwardsCompat.uitkMetric.uitkMetric-orientation-horizontal.uitkMetric-size-medium .uitkMetricContent-subvalue {
-  margin-top: -2px;
+.backwardsCompat.uitkMetric.uitkMetric-orientation-horizontal.uitkMetric-size-medium .uitkMetricContent-subvalue {
+  margin-top: var(--backwardsCompat-metric-horizontal-medium-subvalue-marginTop);
 }
 
 /* Size large */
 .backwardsCompat.uitkMetric.uitkMetric-orientation-horizontal.uitkMetric-size-large .uitkMetricContent {
   margin-top: -1px;
 }
-.uitk-density-medium .backwardsCompat.uitkMetric.uitkMetric-orientation-horizontal.uitkMetric-size-large .uitkMetricContent-subvalue {
-  margin-top: -10px;
-}
-.uitk-density-high .backwardsCompat.uitkMetric.uitkMetric-orientation-horizontal.uitkMetric-size-large .uitkMetricContent-subvalue {
-  margin-top: -11px;
-}
-.uitk-density-low .backwardsCompat.uitkMetric.uitkMetric-orientation-horizontal.uitkMetric-size-large .uitkMetricContent-subvalue {
-  margin-top: -9px;
-}
-.uitk-density-touch .backwardsCompat.uitkMetric.uitkMetric-orientation-horizontal.uitkMetric-size-large .uitkMetricContent-subvalue {
-  margin-top: -8px;
+.backwardsCompat.uitkMetric.uitkMetric-orientation-horizontal.uitkMetric-size-large .uitkMetricContent-subvalue {
+  margin-top: var(--backwardsCompat-metric-horizontal-large-subvalue-marginTop);
 }
 
 /* VERTICAL */
 
 /* Size small */
-.uitk-density-medium .backwardsCompat.uitkMetric.uitkMetric-orientation-vertical.uitkMetric-size-small .uitkMetricContent-value-container {
-  margin-top: 2px;
+.backwardsCompat.uitkMetric.uitkMetric-orientation-vertical.uitkMetric-size-small .uitkMetricContent-value-container {
+  margin-top: var(--backwardsCompat-metric-vertical-small-value-container-marginTop);
 }
-.uitk-density-high .backwardsCompat.uitkMetric.uitkMetric-orientation-vertical.uitkMetric-size-small .uitkMetricContent-value-container {
-  margin-top: 1px;
-}
-.uitk-density-low .backwardsCompat.uitkMetric.uitkMetric-orientation-vertical.uitkMetric-size-small .uitkMetricContent-value-container {
-  margin-top: 3px;
-}
-.uitk-density-touch .backwardsCompat.uitkMetric.uitkMetric-orientation-vertical.uitkMetric-size-small .uitkMetricContent-value-container {
-  margin-top: 4px;
-}
-.uitk-density-medium .backwardsCompat.uitkMetric.uitkMetric-orientation-vertical.uitkMetric-size-small .uitkMetricContent-subvalue {
-  margin-top: 2px;
-}
-.uitk-density-high .backwardsCompat.uitkMetric.uitkMetric-orientation-vertical.uitkMetric-size-small .uitkMetricContent-subvalue {
-  margin-top: 2px;
-}
-.uitk-density-low .backwardsCompat.uitkMetric.uitkMetric-orientation-vertical.uitkMetric-size-small .uitkMetricContent-subvalue {
-  margin-top: 3px;
-}
-.uitk-density-touch .backwardsCompat.uitkMetric.uitkMetric-orientation-vertical.uitkMetric-size-small .uitkMetricContent-subvalue {
-  margin-top: 4px;
+.backwardsCompat.uitkMetric.uitkMetric-orientation-vertical.uitkMetric-size-small .uitkMetricContent-subvalue {
+  margin-top: var(--backwardsCompat-metric-vertical-small-subvalue-marginTop);
 }
 
 /* Size medium */
-.uitk-density-medium .backwardsCompat.uitkMetric.uitkMetric-orientation-vertical.uitkMetric-size-medium .uitkMetricContent-value-container {
-  margin-top: 2px;
+.backwardsCompat.uitkMetric.uitkMetric-orientation-vertical.uitkMetric-size-medium .uitkMetricContent-value-container {
+  margin-top: var(--backwardsCompat-metric-vertical-medium-value-container-marginTop);
 }
-.uitk-density-high .backwardsCompat.uitkMetric.uitkMetric-orientation-vertical.uitkMetric-size-medium .uitkMetricContent-value-container {
-  margin-top: 1px;
-}
-.uitk-density-low .backwardsCompat.uitkMetric.uitkMetric-orientation-vertical.uitkMetric-size-medium .uitkMetricContent-value-container {
-  margin-top: 3px;
-}
-.uitk-density-touch .backwardsCompat.uitkMetric.uitkMetric-orientation-vertical.uitkMetric-size-medium .uitkMetricContent-value-container {
-  margin-top: 4px;
-}
-.uitk-density-medium .backwardsCompat.uitkMetric.uitkMetric-orientation-vertical.uitkMetric-size-medium .uitkMetricContent-subvalue {
-  margin-top: 2px;
-}
-.uitk-density-high .backwardsCompat.uitkMetric.uitkMetric-orientation-vertical.uitkMetric-size-medium .uitkMetricContent-subvalue {
-  margin-top: 2px;
-}
-.uitk-density-low .backwardsCompat.uitkMetric.uitkMetric-orientation-vertical.uitkMetric-size-medium .uitkMetricContent-subvalue {
-  margin-top: 3px;
-}
-.uitk-density-touch .backwardsCompat.uitkMetric.uitkMetric-orientation-vertical.uitkMetric-size-medium .uitkMetricContent-subvalue {
-  margin-top: 4px;
+.backwardsCompat.uitkMetric.uitkMetric-orientation-vertical.uitkMetric-size-medium .uitkMetricContent-subvalue {
+  margin-top: var(--backwardsCompat-metric-vertical-medium-subvalue-marginTop);
 }
 
 /* Size large */
-.uitk-density-medium .backwardsCompat.uitkMetric.uitkMetric-orientation-vertical.uitkMetric-size-large .uitkMetricContent-value-container {
-  margin-top: 2px;
+.backwardsCompat.uitkMetric.uitkMetric-orientation-vertical.uitkMetric-size-large .uitkMetricContent-value-container {
+  margin-top: var(--backwardsCompat-metric-vertical-large-value-container-marginTop);
 }
-.uitk-density-high .backwardsCompat.uitkMetric.uitkMetric-orientation-vertical.uitkMetric-size-large .uitkMetricContent-value-container {
-  margin-top: 1px;
-}
-.uitk-density-low .backwardsCompat.uitkMetric.uitkMetric-orientation-vertical.uitkMetric-size-large .uitkMetricContent-value-container {
-  margin-top: 3px;
-}
-.uitk-density-touch .backwardsCompat.uitkMetric.uitkMetric-orientation-vertical.uitkMetric-size-large .uitkMetricContent-value-container {
-  margin-top: 4px;
-}
-.uitk-density-medium .backwardsCompat.uitkMetric.uitkMetric-orientation-vertical.uitkMetric-size-large .uitkMetricContent-subvalue {
-  margin-top: 2px;
-}
-.uitk-density-high .backwardsCompat.uitkMetric.uitkMetric-orientation-vertical.uitkMetric-size-large .uitkMetricContent-subvalue {
-  margin-top: 1px;
-}
-.uitk-density-low .backwardsCompat.uitkMetric.uitkMetric-orientation-vertical.uitkMetric-size-large .uitkMetricContent-subvalue {
-  margin-top: 3px;
-}
-.uitk-density-touch .backwardsCompat.uitkMetric.uitkMetric-orientation-vertical.uitkMetric-size-large .uitkMetricContent-subvalue {
-  margin-top: 4px;
+.backwardsCompat.uitkMetric.uitkMetric-orientation-vertical.uitkMetric-size-large .uitkMetricContent-subvalue {
+  margin-top: var(--backwardsCompat-metric-vertical-large-subvalue-marginTop);
 }

--- a/packages/lab/src/pagination/Pagination.css
+++ b/packages/lab/src/pagination/Pagination.css
@@ -1,19 +1,19 @@
-.uitk-density-medium .uitkPagination {
+.uitk-density-medium {
   --pagination-button-size: 28px;
   --pagination-fontSize: 12px;
 }
 
-.uitk-density-high .uitkPagination {
+.uitk-density-high {
   --pagination-button-size: 20px;
   --pagination-fontSize: 11px;
 }
 
-.uitk-density-low .uitkPagination {
+.uitk-density-low {
   --pagination-button-size: 36px;
   --pagination-fontSize: 14px;
 }
 
-.uitk-density-touch .uitkPagination {
+.uitk-density-touch {
   --pagination-button-size: 44px;
   --pagination-fontSize: 16px;
 }

--- a/packages/lab/src/tokenized-input/TokenizedInput.css
+++ b/packages/lab/src/tokenized-input/TokenizedInput.css
@@ -1,22 +1,22 @@
 /* Styles applied to root component (TokenizedInput) */
-.uitk-density-medium .uitkTokenizedInput {
+.uitk-density-medium {
   --tokenized-input-gutter-size: var(--uitk-size-basis-unit);
   --tokenized-input-pill-group-y-padding: calc(var(--uitk-size-unit) / 2);
   --tokenized-input-last-pill-margin: var(--uitk-size-unit);
 }
-.uitk-density-touch .uitkTokenizedInput {
+.uitk-density-touch {
   --tokenized-input-gutter-size: var(--uitk-size-basis-unit);
   --tokenized-input-pill-group-y-padding: calc(var(--uitk-size-unit) / 2 + 2px);
   --tokenized-input-last-pill-margin: calc(var(--uitk-size-unit) / 2);
 }
 
-.uitk-density-low .uitkTokenizedInput {
+.uitk-density-low {
   --tokenized-input-gutter-size: var(--uitk-size-basis-unit);
   --tokenized-input-pill-group-y-padding: calc(var(--uitk-size-unit) / 2 + 1px);
   --tokenized-input-last-pill-margin: calc(var(--uitk-size-unit) / 2);
 }
 
-.uitk-density-high .uitkTokenizedInput {
+.uitk-density-high {
   --tokenized-input-gutter-size: calc(var(--uitk-size-basis-unit) - 1px);
   --tokenized-input-pill-group-y-padding: calc(var(--uitk-size-unit) / 2 + 1px);
   --tokenized-input-last-pill-margin: var(--uitk-size-unit);


### PR DESCRIPTION
Part of CSS clean up: 

- Remove component name classes when tokens are density dependent (see issue #330 for explanation) - go to Contact Details compare with TK1 story and switch to touch density for obvious example of this issue (fixed with this PR)
- Includes creation of tokens where necessary (e.g. ControlLabel)
- Includes Grid.css updates to use CSS API for components with special values for uitk-density-ultrahigh