### PR TITLE
Remove focus visible styling API; always use characteristic directly 

### DIFF
--- a/.changeset/curly-llamas-sing.md
+++ b/.changeset/curly-llamas-sing.md
@@ -1,0 +1,7 @@
+---
+"@jpmorganchase/uitk-core": minor
+"@jpmorganchase/uitk-grid": minor
+"@jpmorganchase/uitk-lab": minor
+---
+
+Focus visible API removed from components; always use theme characteristics directly for focus visible styling

--- a/packages/core/src/button/Button.css
+++ b/packages/core/src/button/Button.css
@@ -1,11 +1,3 @@
-/* Style applied to the root element */
-.uitkButton {
-  --button-focused-outlineStyle: var(--uitkButton-focused-outlineStyle, var(--uitk-focused-outlineStyle));
-  --button-focused-outlineWidth: var(--uitkButton-focused-outlineWidth, var(--uitk-focused-outlineWidth));
-  --button-focused-outlineColor: var(--uitkButton-focused-outlineColor, var(--uitk-focused-outlineColor));
-  --button-focused-outlineOffset: var(--uitkButton-focused-outlineOffset, var(--uitk-focused-outlineOffset));
-}
-
 /* Icon API @ignore */
 .uitkButton {
   --uitkIcon-letterSpacing: 0;
@@ -143,10 +135,10 @@
 
 /* Added .uitkButton:focus for browsers don't support :focus-visible, like Firefox */
 .uitkButton:focus {
-  outline-style: var(--button-focused-outlineStyle);
-  outline-width: var(--button-focused-outlineWidth);
-  outline-color: var(--button-focused-outlineColor);
-  outline-offset: var(--button-focused-outlineOffset);
+  outline-style: var(--uitk-focused-outlineStyle);
+  outline-width: var(--uitk-focused-outlineWidth);
+  outline-color: var(--uitk-focused-outlineColor);
+  outline-offset: var(--uitk-focused-outlineOffset);
 }
 
 .uitkButton:focus:not(:focus-visible) {
@@ -154,10 +146,10 @@
 }
 
 .uitkButton:focus-visible {
-  outline-style: var(--button-focused-outlineStyle);
-  outline-width: var(--button-focused-outlineWidth);
-  outline-color: var(--button-focused-outlineColor);
-  outline-offset: var(--button-focused-outlineOffset);
+  outline-style: var(--uitk-focused-outlineStyle);
+  outline-width: var(--uitk-focused-outlineWidth);
+  outline-color: var(--uitk-focused-outlineColor);
+  outline-offset: var(--uitk-focused-outlineOffset);
 }
 
 /* Pseudo-class applied to the root element on focus when Button is not active */

--- a/packages/core/src/form-field/FormField.css
+++ b/packages/core/src/form-field/FormField.css
@@ -1,17 +1,13 @@
 .uitk-density-high {
-  --formField-focused-outline-bottom: 4px;
   --formLabel-top-marginBottom: 2px;
 }
 .uitk-density-medium {
-  --formField-focused-outline-bottom: 2px;
   --formLabel-top-marginBottom: 2px;
 }
 .uitk-density-low {
-  --formField-focused-outline-bottom: 2px;
   --formLabel-top-marginBottom: 4px;
 }
 .uitk-density-touch {
-  --formField-focused-outline-bottom: 0px;
   --formLabel-top-marginBottom: 8px;
 }
 
@@ -22,9 +18,6 @@
   --formField-activationIndicator-style: var(--uitk-editable-borderStyle);
   --formField-background: var(--uitk-editable-background-medium);
   --formField-focused-outlineColor: var(--uitk-focused-outlineColor);
-  --formField-focused-outlineOffset: var(--uitkFormField-focused-outlineOffset, var(--uitk-focused-outlineOffset));
-  --formField-focused-outlineStyle: var(--uitkFormField-focused-outlineStyle, var(--uitk-focused-outlineStyle));
-  --formField-focused-outlineWidth: var(--uitkFormField-focused-outlineWidth, var(--uitk-focused-outlineWidth));
   /* Set to 0 until helper text class provided */
   --formField-helperText-height: 0px;
 }
@@ -196,9 +189,9 @@
   left: 0;
   right: 0;
   bottom: var(--uitkFormFieldHelperText-lineHeight, var(--formField-helperText-height, 0px));
-  outline-color: var(--uitkFormField-focused-outlineColor, var(--formField-focused-outlineColor));
-  outline-style: var(--uitkFormField-focused-outlineStyle, var(--formField-focused-outlineStyle));
-  outline-width: var(--uitkFormField-focused-outlineWidth, var(--formField-focused-outlineWidth));
+  outline-color: var(--formField-focused-outlineColor);
+  outline-style: var(--uitk-focused-outlineStyle);
+  outline-width: var(--uitk-focused-outlineWidth);
 }
 
 /* Class applied on focus with `labelTop={true}` and helper text provided */
@@ -209,9 +202,9 @@
   left: 0;
   right: 0;
   bottom: var(--formField-helperText-height, 0px);
-  outline-color: var(--uitkFormField-focused-outlineColor, var(--formField-focused-outlineColor));
-  outline-style: var(--uitkFormField-focused-outlineStyle, var(--formField-focused-outlineStyle));
-  outline-width: var(--uitkFormField-focused-outlineWidth, var(--formField-focused-outlineWidth));
+  outline-color: var(--formField-focused-outlineColor);
+  outline-style: var(--uitk-focused-outlineStyle);
+  outline-width: var(--uitk-focused-outlineWidth);
 }
 
 .uitkFormField-labelLeft.uitkFormField-focused:before {
@@ -226,9 +219,9 @@
   left: 0;
   right: 0;
   bottom: 0px;
-  outline-color: var(--uitkFormField-focused-outlineColor, var(--formField-focused-outlineColor));
-  outline-style: var(--uitkFormField-focused-outlineStyle, var(--formField-focused-outlineStyle));
-  outline-width: var(--uitkFormField-focused-outlineWidth, var(--formField-focused-outlineWidth));
+  outline-color: var(--formField-focused-outlineColor);
+  outline-style: var(--uitk-focused-outlineStyle);
+  outline-width: var(--uitk-focused-outlineWidth);
   z-index: -1;
 }
 

--- a/packages/core/src/switch/Switch.css
+++ b/packages/core/src/switch/Switch.css
@@ -181,10 +181,10 @@
   display: block;
   height: var(--uitkSwitch-focused-height, var(--uitk-size-switch));
   left: var(--uitkSwitch-focused-left, -2px);
-  outline-style: var(--uitkSwitch-focused-outlineStyle, var(--uitk-focused-outlineStyle));
-  outline-width: var(--uitkSwitch-focused-outlineWidth, var(--uitk-focused-outlineWidth));
-  outline-color: var(--uitkSwitch-focused-outlineColor, var(--uitk-focused-outlineColor));
-  outline-offset: var(--uitkSwitch-focused-outlineOffset, var(--uitk-focused-outlineOffset));
+  outline-style: var(--uitk-focused-outlineStyle);
+  outline-width: var(--uitk-focused-outlineWidth);
+  outline-color: var(--uitk-focused-outlineColor);
+  outline-offset: var(--uitk-focused-outlineOffset);
   position: absolute;
   top: var(--uitkSwitch-focused-top, -2px);
   width: var(--uitkSwitch-focused-width, var(--switch-width));

--- a/packages/grid/src/grid/components/Grid.css
+++ b/packages/grid/src/grid/components/Grid.css
@@ -33,7 +33,6 @@
   --checkbox-density-bar-height: 3px;
   --checkbox-size: 12px;
   /*FormField*/
-  --formField-focused-outline-bottom: 4px;
   --formLabel-top-marginBottom: 2px;
   /*FormHelperText*/
   --formField-helperText-marginTop: 2px;

--- a/packages/lab/src/accordion/Accordion.css
+++ b/packages/lab/src/accordion/Accordion.css
@@ -50,11 +50,6 @@
   --accordion-summary-text-color-disabled: var(--uitkAccordionSummary-text-color-disabled, var(--uitk-text-primary-foreground-disabled));
   --accordion-summary-text-color-hover: var(--uitkAccordionSummary-text-color-hover, var(--uitk-text-primary-foreground));
 
-  --accordion-summary-focus-outlineStyle: var(--uitk-focused-outlineStyle);
-  --accordion-summary-focus-outlineWidth: var(--uitk-focused-outlineWidth);
-  --accordion-summary-focus-outlineColor: var(--uitk-focused-outlineColor);
-  --accordion-summary-focus-outlineOffset: var(--uitk-focused-outlineOffset);
-
   --accordion-summary-icon-transition-default: transform 150ms cubic-bezier(0.4, 0, 0.2, 1);
   --accordion-summary-icon-transform: var(--uitkAccordionSummary-icon-expand-transform, rotate(90deg));
   --accordion-summary-icon-transition: var(--uitkAccordionSummary-icon-transition, var(--accordion-summary-icon-transition-default));
@@ -91,10 +86,10 @@
 }
 
 .uitkAccordionSummary:focus-visible {
-  outline-style: var(--accordion-summary-focus-outlineStyle);
-  outline-width: var(--accordion-summary-focus-outlineWidth);
-  outline-color: var(--accordion-summary-focus-outlineColor);
-  outline-offset: var(--accordion-summary-focus-outlineOffset);
+  outline-style: var(--uitk-focused-outlineStyle);
+  outline-width: var(--uitk-focused-outlineWidth);
+  outline-color: var(--uitk-focused-outlineColor);
+  outline-offset: var(--uitk-focused-outlineOffset);
 }
 
 .uitkAccordionSummary:hover:not(.uitkAccordionSummary-disabled) {

--- a/packages/lab/src/link/Link.css
+++ b/packages/lab/src/link/Link.css
@@ -3,11 +3,8 @@
   --link-color-active: var(--uitk-text-link-foreground-hover);
   --link-color-focus: var(--uitkLink-color-focus, var(--link-color-hover));
   --link-color-disabled: var(--uitk-text-primary-foreground-disabled);
-
   --link-textDecoration: var(--uitk-text-link-textDecoration);
-
   --link-fontFamily: var(--uitk-text-fontFamily);
-  --link-focus-outline: var(--uitk-focused-outline);
 }
 
 .uitkLink {
@@ -36,7 +33,7 @@
 }
 
 .uitkLink:focus {
-  outline: var(--link-focus-outline);
+  outline: var(--uitk-focused-outline);
   /* When focused, we also want hover style */
   color: var(--link-color-focus);
 }

--- a/packages/lab/src/list-deprecated/ListItem.css
+++ b/packages/lab/src/list-deprecated/ListItem.css
@@ -3,7 +3,7 @@
   --list-item-text-color: var(--uitk-selectable-foreground);
   --list-item-background: var(--uitk-selectable-background);
   --list-item-background-hover: var(--uitk-selectable-background-hover);
-  --list-item-selected-focus-visible-outlineColor: var(--uitk-accent-foreground); /* TODO: Check token with design */
+  --list-item-selected-focus-outlineColor: var(--uitk-accent-foreground); /* TODO: Check token with design */
 
   --list-item-text-color-active: var(--uitk-selectable-foreground-selected);
   --list-item-background-active: var(--uitk-selectable-background-selected);
@@ -17,12 +17,6 @@
   --list-item-padding: 0 var(--uitk-size-unit);
 
   /* Misc. */
-
-  --list-item-focus-visible-outlineStyle: var(--uitk-focused-outlineStyle);
-  --list-item-focus-visible-outlineWidth: var(--uitk-focused-outlineWidth);
-  --list-item-focus-visible-outlineColor: var(--uitk-focused-outlineColor);
-  --list-item-focus-visible-outlineOffset: var(--uitk-focused-outlineOffset);
-
   --list-item-gap: 0px;
   --list-item-alignItems: center;
   --list-item-selectable-cursor: pointer;
@@ -91,12 +85,12 @@
   content: "";
   position: absolute;
 
-  outline-style: var(--list-item-focus-visible-outlineStyle);
-  outline-width: var(--list-item-focus-visible-outlineWidth);
-  outline-color: var(--list-item-focus-visible-outlineColor);
-  outline-offset: var(--list-item-focus-visible-outlineOffset);
+  outline-style: var(--uitk-focused-outlineStyle);
+  outline-width: var(--uitk-focused-outlineWidth);
+  outline-color: var(--uitk-focused-outlineColor);
+  outline-offset: var(--uitk-focused-outlineOffset);
 }
 
 .uitkListItemDeprecated-focusVisible.uitkListItemDeprecated-selected:after {
-  outline-color: var(--list-item-selected-focus-visible-outlineColor);
+  outline-color: var(--list-item-selected-focus-outlineColor);
 }

--- a/packages/lab/src/list/ListItem.css
+++ b/packages/lab/src/list/ListItem.css
@@ -2,7 +2,7 @@
   /* Color */
   --list-item-text-color: var(--uitk-selectable-foreground);
   --list-item-background: var(--uitkListItem-background, var(--uitk-selectable-background));
-  --list-item-selected-focus-visible-outlineColor: var(--uitk-color-white);
+  --list-item-selected-focus-outlineColor: var(--uitk-color-white); /* TODO: Check token with design */
   --list-item-text-color-active: var(--uitk-selectable-foreground-selected);
   --list-item-background-active: var(--uitk-selectable-background-selected);
   --list-item-alignItems: center;
@@ -30,7 +30,7 @@
   font-size: var(--uitk-text-fontSize);
   text-align: var(--uitk-text-textAlign);
   line-height: var(--uitk-text-lineHeight);
-  height: var(--uitkListItem-height, auto);
+  height: var(--uitkListItem-height, var(--list-item-height, auto));
   /* Replaced border-bottom with margin. In design spec, the height of the items should not include gap */
   margin-bottom: var(--list-item-gap);
   padding: 0 var(--uitk-size-unit);
@@ -74,7 +74,7 @@
 }
 
 .uitkListItem[aria-selected="true"]:not(.uitkListItem-checkbox).uitkFocusVisible {
-  outline-color: var(--list-item-selected-focus-visible-outlineColor);
+  outline-color: var(--list-item-selected-focus-outlineColor);
 }
 
 .uitkListItem-textWrapper {

--- a/packages/lab/src/tokenized-input/TokenizedInput.css
+++ b/packages/lab/src/tokenized-input/TokenizedInput.css
@@ -25,7 +25,6 @@
 .uitkTokenizedInput {
   --tokenized-input-spacing: var(--uitk-size-unit);
   --tokenized-input-height: var(--uitk-size-base);
-  --tokenized-input-focused-outline: var(--uitk-focused-outline);
 }
 
 .uitkTokenizedInput {
@@ -58,7 +57,7 @@
 
 /* Styles applied to root component if `focused={true}` */
 .uitkTokenizedInput-focused {
-  outline: var(--uitkTokenizedInput-focused-outline, var(--tokenized-input-focused-outline));
+  outline: var(--uitk-focused-outline);
 }
 
 /* Styles applied to root component if `expanded={true}` */

--- a/packages/lab/src/toolbar/Tooltray.css
+++ b/packages/lab/src/toolbar/Tooltray.css
@@ -17,7 +17,6 @@
 }
 
 .uitkTooltray > .Responsive-inner > .uitkToolbarField {
-  /* --uitkButton-focused-outlineStyle: none; */
   flex-shrink: 0;
   flex-grow: 0;
 }

--- a/packages/lab/src/tree/Tree.css
+++ b/packages/lab/src/tree/Tree.css
@@ -1,5 +1,4 @@
 .uitkTree {
-  --tree-borderColor-focusVisible: rgb(141, 154, 179);
   --tree-node-collapse: var(--uitkTree-node-collapse, var(--list-svg-tree-node-collapse));
   --tree-node-expand: var(--uitkTree-node-expand, var(--list-svg-tree-node-expand));
   --tree-node-expanded-transform: var(--uitkTree-node-expanded-transform, none);

--- a/packages/lab/src/tree/TreeNode.css
+++ b/packages/lab/src/tree/TreeNode.css
@@ -3,7 +3,6 @@
   --tree-item-text-color: var(--uitk-selectable-foreground);
   --tree-item-background: var(--uitk-selectable-background);
   --tree-item-background-hover: var(--uitk-selectable-background-hover);
-  --tree-item-selected-focus-visible-outlineColor: var(--uitk-color-white);
 
   --tree-node-height: var(--uitkTreeNode-height, var(--uitk-size-stackable));
   --tree-node-icon-size: 12px;
@@ -136,7 +135,7 @@
   left: var(--tree-offset-left-focusVisible, 0px);
   right: 0;
   bottom: 0px;
-  border: dotted var(--tree-borderColor-focusVisible) 2px;
+  border: dotted rgb(141, 154, 179) 2px; /* FIXME: Needs checking */
   background: var(--list-background-highlighted);
 }
 


### PR DESCRIPTION
As agreed with dev and design - remove focus visible styling API from components; always use characteristic directly (exception for List - which may need to be looked at by design)