### PR TITLE
Revert to FlexLayout not wrapping by default

### DIFF
--- a/.changeset/sour-timers-glow.md
+++ b/.changeset/sour-timers-glow.md
@@ -2,4 +2,4 @@
 "@jpmorganchase/uitk-core": minor
 ---
 
-Change the default wrap value in FlexLayout to false so it matches css Flexbox
+Change the default wrap value in `FlexLayout` to false so it matches css Flexbox and replace `disableWrap` prop with `wrap`

--- a/.changeset/sour-timers-glow.md
+++ b/.changeset/sour-timers-glow.md
@@ -1,0 +1,5 @@
+---
+"@jpmorganchase/uitk-core": minor
+---
+
+Change the default wrap value in FlexLayout to false so it matches css Flexbox

--- a/packages/core/src/__tests__/__e2e__/layout/Flex.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/layout/Flex.cy.tsx
@@ -61,7 +61,7 @@ describe("GIVEN a Flex", () => {
 
   describe("WHEN wrap is set to true", () => {
     it("THEN it should render with flex wrap", () => {
-      cy.mount(<DefaultFlexLayout wrap={true} />);
+      cy.mount(<DefaultFlexLayout wrap />);
 
       cy.get(".uitkFlexLayout").should("have.css", "flex-wrap", "wrap");
     });

--- a/packages/core/src/__tests__/__e2e__/layout/Flex.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/layout/Flex.cy.tsx
@@ -17,10 +17,10 @@ describe("GIVEN a Flex", () => {
       cy.get(".uitkFlexLayout").should("have.css", "flex-direction", "row");
     });
 
-    it("THEN it should render with flex wrap", () => {
+    it("THEN it should render with no flex wrap", () => {
       cy.mount(<DefaultFlexLayout />);
 
-      cy.get(".uitkFlexLayout").should("have.css", "flex-wrap", "wrap");
+      cy.get(".uitkFlexLayout").should("have.css", "flex-wrap", "nowrap");
     });
 
     it("THEN it should render with a default gap", () => {
@@ -34,13 +34,13 @@ describe("GIVEN a Flex", () => {
     it("THEN nested items should not inherit css variables from parent", () => {
       cy.mount(<FlexLayoutNested />);
 
-      cy.get(".uitkFlexLayout").eq(0).should("have.css", "flex-wrap", "nowrap");
+      cy.get(".uitkFlexLayout").eq(0).should("have.css", "flex-wrap", "wrap");
       cy.get(".uitkFlexLayout")
         .eq(0)
         .should("have.css", "justify-content", "space-between");
       cy.get(".uitkFlexLayout").eq(0).should("have.css", "row-gap", "48px");
 
-      cy.get(".uitkFlexLayout").eq(1).should("have.css", "flex-wrap", "wrap");
+      cy.get(".uitkFlexLayout").eq(1).should("have.css", "flex-wrap", "nowrap");
       cy.get(".uitkFlexLayout")
         .eq(1)
         .should("have.css", "justify-content", "flex-start");
@@ -61,19 +61,19 @@ describe("GIVEN a Flex", () => {
 
   describe("WHEN wrap is set to true", () => {
     it("THEN it should render with flex wrap", () => {
-      cy.mount(<DefaultFlexLayout disableWrap={false} />);
+      cy.mount(<DefaultFlexLayout wrap={true} />);
 
       cy.get(".uitkFlexLayout").should("have.css", "flex-wrap", "wrap");
     });
   });
 
   describe("WHEN responsive values are provided", () => {
-    const disableWrap = {
-      xs: false,
-      sm: false,
-      md: false,
-      lg: true,
-      xl: true,
+    const wrap = {
+      xs: true,
+      sm: true,
+      md: true,
+      lg: false,
+      xl: false,
     };
 
     it(
@@ -83,7 +83,7 @@ describe("GIVEN a Flex", () => {
         viewportWidth: 1921,
       },
       () => {
-        cy.mount(<FlexLayoutUsingResponsiveProps disableWrap={disableWrap} />);
+        cy.mount(<FlexLayoutUsingResponsiveProps wrap={wrap} />);
 
         cy.get(".uitkFlexLayout").should("have.css", "flex-wrap", "nowrap");
       }
@@ -96,7 +96,7 @@ describe("GIVEN a Flex", () => {
         viewportWidth: 961,
       },
       () => {
-        cy.mount(<FlexLayoutUsingResponsiveProps disableWrap={disableWrap} />);
+        cy.mount(<FlexLayoutUsingResponsiveProps wrap={wrap} />);
 
         cy.get(".uitkFlexLayout").should("have.css", "flex-wrap", "wrap");
       }
@@ -109,7 +109,7 @@ describe("GIVEN a Flex", () => {
         viewportWidth: 700,
       },
       () => {
-        cy.mount(<FlexLayoutUsingResponsiveProps disableWrap={disableWrap} />);
+        cy.mount(<FlexLayoutUsingResponsiveProps wrap={wrap} />);
 
         cy.get(".uitkFlexLayout").should("have.css", "flex-wrap", "wrap");
       }
@@ -122,7 +122,7 @@ describe("GIVEN a Flex", () => {
         viewportWidth: 600,
       },
       () => {
-        cy.mount(<FlexLayoutUsingResponsiveProps disableWrap={disableWrap} />);
+        cy.mount(<FlexLayoutUsingResponsiveProps wrap={wrap} />);
 
         cy.get(".uitkFlexLayout").should("have.css", "flex-wrap", "wrap");
       }
@@ -130,12 +130,12 @@ describe("GIVEN a Flex", () => {
   });
 
   describe("WHEN custom breakpoints are provided", () => {
-    const disableWrap = {
-      xs: false,
-      sm: false,
-      md: false,
-      lg: true,
-      xl: true,
+    const wrap = {
+      xs: true,
+      sm: true,
+      md: true,
+      lg: false,
+      xl: false,
     };
 
     const breakpoints = {
@@ -155,7 +155,7 @@ describe("GIVEN a Flex", () => {
       () => {
         cy.mount(
           <ToolkitProvider breakpoints={breakpoints}>
-            <FlexLayoutUsingResponsiveProps disableWrap={disableWrap} />
+            <FlexLayoutUsingResponsiveProps wrap={wrap} />
           </ToolkitProvider>
         );
 
@@ -172,7 +172,7 @@ describe("GIVEN a Flex", () => {
       () => {
         cy.mount(
           <ToolkitProvider breakpoints={breakpoints}>
-            <FlexLayoutUsingResponsiveProps disableWrap={disableWrap} />
+            <FlexLayoutUsingResponsiveProps wrap={wrap} />
           </ToolkitProvider>
         );
 
@@ -189,7 +189,7 @@ describe("GIVEN a Flex", () => {
       () => {
         cy.mount(
           <ToolkitProvider breakpoints={breakpoints}>
-            <FlexLayoutUsingResponsiveProps disableWrap={disableWrap} />
+            <FlexLayoutUsingResponsiveProps wrap={wrap} />
           </ToolkitProvider>
         );
 
@@ -206,7 +206,7 @@ describe("GIVEN a Flex", () => {
       () => {
         cy.mount(
           <ToolkitProvider breakpoints={breakpoints}>
-            <FlexLayoutUsingResponsiveProps disableWrap={disableWrap} />
+            <FlexLayoutUsingResponsiveProps wrap={wrap} />
           </ToolkitProvider>
         );
 

--- a/packages/core/src/layout/FlexLayout/FlexLayout.css
+++ b/packages/core/src/layout/FlexLayout/FlexLayout.css
@@ -7,7 +7,7 @@
   --flex-layout-gap-multiplier: var(--flex-layout-gap-density-multiplier, 3);
   --flex-layout-layout-display: flex;
   --flex-layout-direction: row;
-  --flex-layout-wrap: wrap;
+  --flex-layout-wrap: nowrap;
   --flex-layout-justify: flex-start;
   --flex-layout-align: stretch;
   --flex-layout-separator: var(--uitk-separable-borderWidth);

--- a/packages/core/src/layout/FlexLayout/FlexLayout.tsx
+++ b/packages/core/src/layout/FlexLayout/FlexLayout.tsx
@@ -41,9 +41,9 @@ export interface FlexLayoutProps extends HTMLAttributes<HTMLDivElement> {
    */
   separators?: LayoutSeparator | true;
   /**
-   * Disable wrapping so flex items try to fit onto one line, default is false.
+   * Allow the items to wrap as needed, default is false.
    */
-  disableWrap?: ResponsiveProp<boolean>;
+  wrap?: ResponsiveProp<boolean>;
 }
 
 export const FlexLayout = forwardRef<HTMLDivElement, FlexLayoutProps>(
@@ -57,7 +57,7 @@ export const FlexLayout = forwardRef<HTMLDivElement, FlexLayoutProps>(
       justify,
       separators,
       style,
-      disableWrap = false,
+      wrap,
       ...rest
     },
     ref
@@ -69,15 +69,14 @@ export const FlexLayout = forwardRef<HTMLDivElement, FlexLayoutProps>(
 
     const flexGap = useResponsiveProp(gap, 3);
     const flexDirection = useResponsiveProp(direction, "row");
-    const flexDisableWrap = useResponsiveProp(disableWrap, true);
-
+    const flexWrap = useResponsiveProp(wrap, false);
     const flexLayoutStyles = {
       ...style,
       "--flex-layout-align": align && addPrefix(align),
       "--flex-layout-direction": flexDirection,
       "--flex-layout-gap-multiplier": flexGap,
       "--flex-layout-justify": justify && addPrefix(justify),
-      "--flex-layout-wrap": flexDisableWrap ? "nowrap" : "wrap",
+      "--flex-layout-wrap": flexWrap ? "wrap" : "nowrap",
     };
 
     return (

--- a/packages/core/src/layout/FlowLayout/FlowLayout.tsx
+++ b/packages/core/src/layout/FlowLayout/FlowLayout.tsx
@@ -3,7 +3,7 @@ import { FlexLayout, FlexLayoutProps } from "../FlexLayout";
 
 export interface FlowLayoutProps extends HTMLAttributes<HTMLDivElement> {
   /**
-   * Defines the default behavior for how flex items are laid out along the cross axis on the current line, , default is "stretch".
+   * Defines the default behavior for how flex items are laid out along the cross axis on the current line, default is "stretch".
    */
   align?: FlexLayoutProps["align"];
   /**
@@ -21,8 +21,6 @@ export interface FlowLayoutProps extends HTMLAttributes<HTMLDivElement> {
 }
 export const FlowLayout = forwardRef<HTMLDivElement, FlowLayoutProps>(
   function FlowLayout({ ...rest }, ref) {
-    return (
-      <FlexLayout direction="row" ref={ref} disableWrap={false} {...rest} />
-    );
+    return <FlexLayout direction="row" ref={ref} wrap={true} {...rest} />;
   }
 );

--- a/packages/core/src/layout/FlowLayout/FlowLayout.tsx
+++ b/packages/core/src/layout/FlowLayout/FlowLayout.tsx
@@ -21,6 +21,6 @@ export interface FlowLayoutProps extends HTMLAttributes<HTMLDivElement> {
 }
 export const FlowLayout = forwardRef<HTMLDivElement, FlowLayoutProps>(
   function FlowLayout({ ...rest }, ref) {
-    return <FlexLayout direction="row" ref={ref} wrap={true} {...rest} />;
+    return <FlexLayout direction="row" ref={ref} wrap {...rest} />;
   }
 );

--- a/packages/core/src/layout/ParentChildLayout/ParentChildLayout.tsx
+++ b/packages/core/src/layout/ParentChildLayout/ParentChildLayout.tsx
@@ -114,7 +114,7 @@ export const ParentChildLayout = forwardRef<
     <FlexLayout
       className={cx(className, withBaseName())}
       ref={ref}
-      disableWrap
+      wrap={false}
       {...rest}
     >
       {stackedView ? (

--- a/packages/core/src/layout/ParentChildLayout/ParentChildLayout.tsx
+++ b/packages/core/src/layout/ParentChildLayout/ParentChildLayout.tsx
@@ -111,12 +111,7 @@ export const ParentChildLayout = forwardRef<
   };
 
   return (
-    <FlexLayout
-      className={cx(className, withBaseName())}
-      ref={ref}
-      wrap={false}
-      {...rest}
-    >
+    <FlexLayout className={cx(className, withBaseName())} ref={ref} {...rest}>
       {stackedView ? (
         stackedViewChildren[stackedViewElement]
       ) : (

--- a/packages/core/src/layout/SplitLayout/SplitLayout.tsx
+++ b/packages/core/src/layout/SplitLayout/SplitLayout.tsx
@@ -22,9 +22,9 @@ export interface SplitLayoutProps extends HTMLAttributes<HTMLDivElement> {
    */
   separators?: FlexLayoutProps["separators"];
   /**
-   * Disable wrapping so flex items try to fit onto one line, default is false.
+   * Allow the items to wrap as needed, default is true.
    */
-  disableWrap?: FlexLayoutProps["disableWrap"];
+  wrap?: FlexLayoutProps["wrap"];
   /**
    * Controls the space between items.
    */
@@ -59,7 +59,7 @@ export const SplitLayout = forwardRef<HTMLDivElement, SplitLayoutProps>(
       leftSplitItem,
       rightSplitItem,
       separators,
-      disableWrap = false,
+      wrap = true,
       className,
       gap,
       ...rest
@@ -70,7 +70,7 @@ export const SplitLayout = forwardRef<HTMLDivElement, SplitLayoutProps>(
       <FlexLayout
         direction="row"
         ref={ref}
-        disableWrap={disableWrap}
+        wrap={wrap}
         gap={gap}
         separators={separators}
         className={cx(withBaseName(), className)}

--- a/packages/core/src/layout/StackLayout/StackLayout.tsx
+++ b/packages/core/src/layout/StackLayout/StackLayout.tsx
@@ -19,7 +19,7 @@ export interface StackLayoutProps extends HTMLAttributes<HTMLDivElement> {
 export const StackLayout = forwardRef<HTMLDivElement, StackLayoutProps>(
   function StackLayout({ children, ...rest }, ref) {
     return (
-      <FlexLayout direction="column" wrap={false} ref={ref} {...rest}>
+      <FlexLayout direction="column" ref={ref} {...rest}>
         {children}
       </FlexLayout>
     );

--- a/packages/core/src/layout/StackLayout/StackLayout.tsx
+++ b/packages/core/src/layout/StackLayout/StackLayout.tsx
@@ -19,7 +19,7 @@ export interface StackLayoutProps extends HTMLAttributes<HTMLDivElement> {
 export const StackLayout = forwardRef<HTMLDivElement, StackLayoutProps>(
   function StackLayout({ children, ...rest }, ref) {
     return (
-      <FlexLayout direction="column" disableWrap ref={ref} {...rest}>
+      <FlexLayout direction="column" wrap={false} ref={ref} {...rest}>
         {children}
       </FlexLayout>
     );

--- a/packages/core/stories/layout/border-layout.stories.tsx
+++ b/packages/core/stories/layout/border-layout.stories.tsx
@@ -321,7 +321,7 @@ const Contacts: ComponentStory<typeof BorderLayout> = (args) => {
       <BorderItem position="main">
         <div className="border-layout-contacts">
           <h2>My contacts</h2>
-          <FlexLayoutComposite />
+          <FlexLayoutComposite wrap={true} />
         </div>
       </BorderItem>
 

--- a/packages/core/stories/layout/border-layout.stories.tsx
+++ b/packages/core/stories/layout/border-layout.stories.tsx
@@ -321,7 +321,7 @@ const Contacts: ComponentStory<typeof BorderLayout> = (args) => {
       <BorderItem position="main">
         <div className="border-layout-contacts">
           <h2>My contacts</h2>
-          <FlexLayoutComposite wrap={true} />
+          <FlexLayoutComposite wrap />
         </div>
       </BorderItem>
 

--- a/packages/core/stories/layout/flex-item.stories.tsx
+++ b/packages/core/stories/layout/flex-item.stories.tsx
@@ -35,31 +35,28 @@ export const FlexContent = ({
   ...rest
 }: FlexContentProps) => (
   <div className={classname || "layout-content"} {...rest}>
-    {children || (
-      <p>
-        {number && `${number}. `}Lorem ipsum dolor sit amet, consectetur
-        adipisicing.
-      </p>
-    )}
+    {children || <p>Item {number && number}</p>}
   </div>
 );
 
 const FlexItemStory: ComponentStory<typeof FlexItem> = (args) => {
   return (
-    <FlexLayout disableWrap>
+    <FlexLayout>
       <FlexItem {...args}>
-        <FlexContent classname={"layout-active-content"} />
-      </FlexItem>
-      <FlexItem>
-        <FlexContent>
-          <p>Lorem ipsum dolor sit amet, consectetur adipisicing.</p>
-          <p>Lorem ipsum dolor sit amet, consectetur adipisicing.</p>
+        <FlexContent classname={"layout-active-content"}>
+          <p>Item</p>
         </FlexContent>
       </FlexItem>
       <FlexItem>
         <FlexContent>
-          <p>Lorem ipsum dolor sit amet, consectetur adipisicing.</p>
-          <p>Lorem ipsum dolor sit amet, consectetur adipisicing.</p>
+          <p>This is a larger item</p>
+          <p>This is a larger item</p>
+        </FlexContent>
+      </FlexItem>
+      <FlexItem>
+        <FlexContent>
+          <p>This is a larger item</p>
+          <p>This is a larger item</p>
         </FlexContent>
       </FlexItem>
     </FlexLayout>

--- a/packages/core/stories/layout/flex-layout.stories.tsx
+++ b/packages/core/stories/layout/flex-layout.stories.tsx
@@ -53,7 +53,7 @@ export default {
       options: ["start", "center", "end", true],
       control: { type: "select" },
     },
-    disableWrap: {
+    wrap: {
       control: "boolean",
     },
   },
@@ -96,7 +96,11 @@ const Responsive: ComponentStory<typeof FlexLayout> = (args) => {
   return (
     <FlexLayout {...args}>
       {Array.from({ length: 6 }, (_, index) => (
-        <FlexContent key={index} number={index + 1} />
+        <FlexContent
+          key={index}
+          number={index + 1}
+          style={{ minWidth: 200, textAlign: "center" }}
+        />
       ))}
     </FlexLayout>
   );
@@ -108,9 +112,9 @@ FlexLayoutUsingResponsiveProps.args = {
     xs: "column",
     md: "row",
   },
-  disableWrap: {
-    xs: false,
-    lg: true,
+  wrap: {
+    xs: true,
+    lg: false,
   },
 };
 
@@ -135,6 +139,9 @@ const FlexLayoutStorySimpleUsage: ComponentStory<typeof FlexLayout> = (
   );
 };
 export const FlexLayoutSimpleUsage = FlexLayoutStorySimpleUsage.bind({});
+FlexLayoutSimpleUsage.args = {
+  wrap: true,
+};
 
 export const ContactDetailsExample = ({ index }: { index: number }) => (
   <ContactDetails embedded={true} stackAtBreakpoint={0}>
@@ -165,6 +172,9 @@ const ContactCards: ComponentStory<typeof FlexLayout> = (args) => {
   );
 };
 export const FlexLayoutComposite = ContactCards.bind({});
+FlexLayoutComposite.args = {
+  wrap: true,
+};
 
 const FlexLayoutNestedExample: ComponentStory<typeof FlexLayout> = (args) => {
   return (
@@ -186,7 +196,7 @@ const FlexLayoutNestedExample: ComponentStory<typeof FlexLayout> = (args) => {
 export const FlexLayoutNested = FlexLayoutNestedExample.bind({});
 FlexLayoutNested.args = {
   justify: "space-between",
-  disableWrap: true,
+  wrap: true,
   gap: 6,
 };
 
@@ -201,7 +211,7 @@ const sectionFormContent = (
     <h3>Section title</h3>
     {Array.from({ length: 3 }, (_, index) => (
       <>
-        <FlexLayout disableWrap key={index}>
+        <FlexLayout key={index}>
           {Array.from({ length: 2 }, (_, index) => (
             <FormFieldExample key={index} />
           ))}
@@ -238,9 +248,7 @@ export const SectionForm: ComponentStory<typeof FlexLayout> = (args) => {
 
 export const Blog = () => (
   <StackLayout>
-    <FlexLayout
-      disableWrap={{ xs: false, sm: false, md: true, lg: true, xl: true }}
-    >
+    <FlexLayout wrap={{ xs: true, sm: true, md: false, lg: false, xl: false }}>
       <FlexItem grow={1}>
         <div className="flex-blog-image flex-blog-image-one" />
       </FlexItem>
@@ -269,9 +277,7 @@ export const Blog = () => (
       </FlexItem>
     </FlexLayout>
 
-    <FlexLayout
-      disableWrap={{ xs: false, sm: false, md: true, lg: true, xl: true }}
-    >
+    <FlexLayout wrap={{ xs: true, sm: true, md: false, lg: false, xl: false }}>
       <FlexItem grow={1}>
         <div className="flex-blog-image flex-blog-image-two" />
       </FlexItem>
@@ -294,9 +300,7 @@ export const Blog = () => (
       </FlexItem>
     </FlexLayout>
 
-    <FlexLayout
-      disableWrap={{ xs: false, sm: false, md: true, lg: true, xl: true }}
-    >
+    <FlexLayout wrap={{ xs: true, sm: true, md: false, lg: false, xl: false }}>
       <FlexItem grow={1}>
         <div className="flex-blog-image flex-blog-image-three" />
       </FlexItem>

--- a/packages/core/stories/layout/layer-layout.stories.tsx
+++ b/packages/core/stories/layout/layer-layout.stories.tsx
@@ -361,7 +361,7 @@ const LayerLayoutTopExample: ComponentStory<typeof LayerLayout> = (args) => {
             officia elit ad. Ullamco adipisicing Lorem amet velit in do
             reprehenderit nostrud eu aute voluptate quis quis.
           </p>
-          <FlexLayout disableWrap>
+          <FlexLayout>
             {Array.from({ length: 4 }, (_, index) => (
               <FormFieldExample key={index} />
             ))}

--- a/packages/core/stories/layout/split-layout.stories.tsx
+++ b/packages/core/stories/layout/split-layout.stories.tsx
@@ -30,7 +30,7 @@ export default {
       options: ["start", "center", "end", true],
       control: { type: "select" },
     },
-    disableWrap: {
+    wrap: {
       type: "boolean",
     },
   },


### PR DESCRIPTION
- Change the default `wrap` value in `FlexLayout` to false so it matches css Flexbox
- Simplify `FlexLayout` examples