### PR TITLE
Update list ref and scrolling api ref

### DIFF
--- a/.changeset/tricky-comics-fry.md
+++ b/.changeset/tricky-comics-fry.md
@@ -1,0 +1,6 @@
+---
+"@jpmorganchase/uitk-lab": minor
+---
+
+- List ref is forwarded to its container HTML element, use `scrollingApiRef` for scrolling
+- Fix empty source passed to VirtualizedList will throw error

--- a/.changeset/tricky-comics-fry.md
+++ b/.changeset/tricky-comics-fry.md
@@ -4,3 +4,4 @@
 
 - List ref is forwarded to its container HTML element, use `scrollingApiRef` for scrolling
 - Fix empty source passed to VirtualizedList will throw error
+- Fixes `uitkHighlighted` className applied to VirtualizedList highlighted item, instead of `uitkListItem-highlighted`

--- a/packages/lab/src/__tests__/__e2e__/combo-box/ComboBox.keyboardNavigation.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/combo-box/ComboBox.keyboardNavigation.cy.tsx
@@ -309,7 +309,7 @@ describe.skip("A multi-select combo box", () => {
 
         cy.findByRole("listbox")
           .findAllByRole("option")
-          .should("not.have.class", "uitkListItem-highlighted");
+          .should("not.have.class", "uitkHighlighted");
       });
     });
 
@@ -370,14 +370,14 @@ describe.skip("A multi-select combo box", () => {
 
         cy.findByRole("listbox")
           .findByRole("option", { name: "Alabama" })
-          .should("have.class", "uitkListItem-highlighted")
+          .should("have.class", "uitkHighlighted")
           .and("have.class", "uitkFocusVisible");
 
         cy.realPress("ArrowDown");
 
         cy.findByRole("listbox")
           .findByRole("option", { name: "Alaska" })
-          .should("have.class", "uitkListItem-highlighted")
+          .should("have.class", "uitkHighlighted")
           .and("have.class", "uitkFocusVisible");
       });
     });
@@ -458,7 +458,7 @@ describe.skip("A multi-select combo box", () => {
         cy.findByRole("listbox")
           .findByRole("option", { name: "Arizona" })
           .should("have.attr", "aria-selected", "true")
-          .and("have.class", "uitkListItem-highlighted");
+          .and("have.class", "uitkHighlighted");
       });
     });
 
@@ -557,7 +557,7 @@ describe.skip("A multi-select combo box", () => {
 
         cy.findByRole("listbox")
           .findAllByRole("option")
-          .should("not.have.class", "uitkListItem-highlighted");
+          .should("not.have.class", "uitkHighlighted");
       });
     });
 

--- a/packages/lab/src/__tests__/__e2e__/combo-box/ComboBox.selection.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/combo-box/ComboBox.selection.cy.tsx
@@ -161,7 +161,7 @@ describe.skip("A multi-select combo box", () => {
 
     cy.findByRole("listbox")
       .findByRole("option", { name: "Alabama" })
-      .should("have.class", "uitkListItem-highlighted");
+      .should("have.class", "uitkHighlighted");
   });
 
   it("should clear input when an item is selected", () => {

--- a/packages/lab/src/__tests__/__e2e__/list/List.scrollApi.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/list/List.scrollApi.cy.tsx
@@ -1,0 +1,52 @@
+import { List, ListProps, ListScrollHandles } from "@jpmorganchase/uitk-lab";
+import { useRef } from "react";
+
+type ItemType = { label: string; value: string };
+const ITEMS: ItemType[] = [
+  { label: "list item 1", value: "item 1" },
+  { label: "list item 2", value: "item 2" },
+  { label: "list item 3", value: "item 3" },
+  { label: "list item 4", value: "item 4" },
+  { label: "list item 5", value: "item 5" },
+];
+
+const TestComponent = (props: ListProps<ItemType>) => {
+  const listScrollRef = useRef<ListScrollHandles<ItemType>>(null);
+  const handleScrollToLast = () => {
+    listScrollRef.current?.scrollToIndex(ITEMS.length - 1);
+  };
+  const handleScrollToFirst = () => {
+    listScrollRef.current?.scrollToIndex(0);
+  };
+
+  return (
+    <div>
+      <button onClick={handleScrollToFirst}>Scroll to first</button>
+      <button onClick={handleScrollToLast}>Scroll to last</button>
+
+      <List {...props} scrollingApiRef={listScrollRef} />
+    </div>
+  );
+};
+
+describe("A list", () => {
+  it("should scroll to item when using scrollingApiRef", () => {
+    cy.mount(<TestComponent source={ITEMS} displayedItemCount={2} />);
+    cy.findByText("list item 1").should("be.visible");
+    cy.findByText("list item 4").should("not.be.visible");
+
+    cy.findByRole("button", { name: "Scroll to last" }).click();
+    cy.findByText("list item 5").should("be.visible");
+    cy.findByText("list item 1").should("not.be.visible");
+
+    cy.findByRole("button", { name: "Scroll to first" }).click();
+    cy.findByText("list item 1").should("be.visible");
+    cy.findByText("list item 5").should("not.be.visible");
+  });
+});
+
+describe("A VirtualizedList", () => {
+  it.skip("should scroll to item when using scrollingApiRef", () => {
+    // Test a scenario where item is beyond render buffer
+  });
+});

--- a/packages/lab/src/list/List.tsx
+++ b/packages/lab/src/list/List.tsx
@@ -1,14 +1,13 @@
-import { makePrefixer, useIdMemo } from "@jpmorganchase/uitk-core";
+import { makePrefixer, useForkRef, useIdMemo } from "@jpmorganchase/uitk-core";
+import cx from "classnames";
 import {
   cloneElement,
-  forwardRef,
   ForwardedRef,
+  forwardRef,
   isValidElement,
   ReactElement,
   useRef,
 } from "react";
-import cx from "classnames";
-import { forwardCallbackProps } from "../utils";
 import {
   CollectionIndexer,
   CollectionItem,
@@ -19,12 +18,12 @@ import {
   useCollectionItems,
   useImperativeScrollingAPI,
 } from "../common-hooks";
-
-import { useListHeight } from "./useListHeight";
+import { forwardCallbackProps } from "../utils";
 
 import { ListItem as DefaultListItem, ListItemProxy } from "./ListItem";
-import { useList } from "./useList";
 import { ListItemProps, ListProps } from "./listTypes";
+import { useList } from "./useList";
+import { useListHeight } from "./useListHeight";
 
 import "./List.css";
 
@@ -72,6 +71,7 @@ export const List = forwardRef(function List<
     selected: selectedProp,
     selectionStrategy,
     checkable = selectionStrategy === "multiple",
+    scrollingApiRef,
     // TODO do we still need these ?
     selectionKeys,
     showEmptyMessage = false,
@@ -82,7 +82,7 @@ export const List = forwardRef(function List<
     width,
     ...htmlAttributes
   }: ListProps<Item, Selection>,
-  forwardedRef?: ForwardedRef<ScrollingAPI<Item>>
+  forwardedRef?: ForwardedRef<HTMLDivElement>
 ) {
   const id = useIdMemo(idProp);
   const rootRef = useRef<HTMLDivElement>(null);
@@ -152,7 +152,7 @@ export const List = forwardRef(function List<
 
   useImperativeScrollingAPI({
     collectionHook,
-    forwardedRef,
+    forwardedRef: scrollingApiRef,
     scrollableRef: rootRef,
     scrollIntoView,
   });
@@ -325,7 +325,7 @@ export const List = forwardRef(function List<
         [withBaseName("collapsible")]: collapsibleHeaders,
       })}
       id={`${id}`}
-      ref={rootRef}
+      ref={useForkRef<HTMLDivElement>(rootRef, forwardedRef)}
       role="listbox"
       style={{ ...styleProp, ...sizeStyles }}
       tabIndex={listDisabled || disableFocus ? undefined : 0}

--- a/packages/lab/src/list/VirtualizedList.tsx
+++ b/packages/lab/src/list/VirtualizedList.tsx
@@ -1,18 +1,19 @@
 import { makePrefixer, useForkRef, useIdMemo } from "@jpmorganchase/uitk-core";
 import cx from "classnames";
-import { forwardRef, ForwardedRef, ReactElement, useRef } from "react";
+import { ForwardedRef, forwardRef, ReactElement, useRef } from "react";
 import {
   CollectionIndexer,
   isSelected,
   SelectionStrategy,
   useCollectionItems,
+  useImperativeScrollingAPI,
 } from "../common-hooks";
 import { useListHeight } from "./useListHeight";
 
 import { ListItem, ListItemProxy } from "./ListItem";
+import { ListProps } from "./listTypes";
 import { useList } from "./useList";
 import { Row, useVirtualization } from "./useVirtualization";
-import { ListProps } from "./listTypes";
 
 import "./List.css";
 
@@ -55,6 +56,7 @@ export const VirtualizedList = forwardRef(function List<
     restoreLastFocus,
     selected: selectedProp,
     selectionStrategy,
+    scrollingApiRef,
     // TODO do we still need these ?
     selectionKeys,
     showEmptyMessage = false,
@@ -97,6 +99,7 @@ export const VirtualizedList = forwardRef(function List<
     highlightedIndex,
     listControlProps,
     listHandlers,
+    scrollIntoView,
     selected,
   } = useList<Item, Selection>({
     collapsibleHeaders,
@@ -134,6 +137,15 @@ export const VirtualizedList = forwardRef(function List<
     viewportRef: rootRef,
     data: collectionHook.data,
     itemGapSize,
+  });
+
+  // FIXME: useImperativeScrollingAPI doesn't work when element is not rendered beyond `renderBuffer`
+  // One potential way: pass `scrollIntoView` to `useVirtualization` and update rows before original `scrollIntoView` been called
+  useImperativeScrollingAPI({
+    collectionHook,
+    forwardedRef: scrollingApiRef,
+    scrollableRef: rootRef,
+    scrollIntoView,
   });
 
   function addItem(
@@ -201,6 +213,7 @@ export const VirtualizedList = forwardRef(function List<
   };
 
   const sizeStyles = {
+    "--list-item-gap": itemGapSize ? `${itemGapSize}px` : undefined,
     minWidth,
     minHeight,
     width: width ?? "100%",

--- a/packages/lab/src/list/VirtualizedList.tsx
+++ b/packages/lab/src/list/VirtualizedList.tsx
@@ -160,7 +160,7 @@ export const VirtualizedList = forwardRef(function List<
         aria-setsize={collectionHook.data.length}
         aria-posinset={pos}
         className={cx(className, {
-          "uitkListItem-highlighted": index === highlightedIndex,
+          uitkHighlighted: index === highlightedIndex,
           uitkFocusVisible: focusVisible === index,
         })}
         data-idx={index}

--- a/packages/lab/src/list/listTypes.ts
+++ b/packages/lab/src/list/listTypes.ts
@@ -1,5 +1,6 @@
 import React, {
   FocusEventHandler,
+  ForwardedRef,
   HTMLAttributes,
   KeyboardEvent,
   KeyboardEventHandler,
@@ -14,6 +15,7 @@ import {
   CollectionItem,
   ListHandlers,
   NavigationHookResult,
+  ScrollingAPI,
   SelectHandler,
   SelectionChangeHandler,
   SelectionHookResult,
@@ -167,6 +169,7 @@ export interface ListProps<
    */
   restoreLastFocus?: boolean;
 
+  scrollingApiRef?: ForwardedRef<ScrollingAPI<Item>>;
   /**
    * The keyboard keys used to effect selection, defaults to SPACE and ENTER
    * TODO maybe this belongs on the SelectionProps interface ?

--- a/packages/lab/src/list/useList.ts
+++ b/packages/lab/src/list/useList.ts
@@ -170,7 +170,7 @@ export const useList = <Item, Selection extends SelectionStrategy = "default">({
     ]
   );
 
-  // This is only appropriate whan we are directly controlling a List,
+  // This is only appropriate when we are directly controlling a List,
   // not when a control is manipulating the list
   const { isScrolling, scrollIntoView } = useViewportTracking({
     containerRef,

--- a/packages/lab/stories/list.stories.tsx
+++ b/packages/lab/stories/list.stories.tsx
@@ -17,6 +17,7 @@ import {
   FlexItem,
   FormField,
   useDensity,
+  StackLayout,
 } from "@jpmorganchase/uitk-core";
 import { ArrowDownIcon, ArrowUpIcon } from "@jpmorganchase/uitk-icons";
 
@@ -403,37 +404,47 @@ export const TabToSelect: Story<ListProps> = () => {
 
 export const ScrollToIndex: Story<ListProps> = () => {
   const inputFieldRef = useRef<HTMLDivElement>(null);
-  const listRef = useRef<ListScrollHandles<string>>(null);
+  const listScrollRef = useRef<ListScrollHandles<string>>(null);
+  const virtualizedListScrollRef = useRef<ListScrollHandles<string>>(null);
   const NUMBER_REGEX = /^(|[1-9][0-9]*)$/;
 
   const handleInputChange: ChangeEventHandler<HTMLInputElement> = (event) => {
     const inputValue = event.target.value;
 
-    if (NUMBER_REGEX.test(inputValue) && listRef.current) {
-      listRef.current.scrollToIndex(parseInt(inputValue, 10) || 0);
+    if (NUMBER_REGEX.test(inputValue)) {
+      listScrollRef.current?.scrollToIndex(parseInt(inputValue, 10) || 0);
+      virtualizedListScrollRef.current?.scrollToIndex(
+        parseInt(inputValue, 10) || 0
+      );
     }
   };
 
   return (
-    <FlexLayout direction="column" style={{ width: 292 }}>
-      <FlexItem>
-        <FormField label="Type an index to scroll to" ref={inputFieldRef}>
-          <Input
-            inputProps={{
-              min: 0,
-              max: usa_states.length - 1,
-            }}
-            onChange={handleInputChange}
-            type="number"
-          />
-        </FormField>
+    <StackLayout style={{ width: 292 * 2 }}>
+      <FormField label="Type an index to scroll to" ref={inputFieldRef}>
+        <Input
+          inputProps={{
+            min: 0,
+            max: usa_states.length - 1,
+          }}
+          onChange={handleInputChange}
+          type="number"
+        />
+      </FormField>
+      <FlexLayout>
         <List
           aria-label="ScrollToIndex List example"
-          ref={listRef}
+          scrollingApiRef={listScrollRef}
           source={usa_states}
         />
-      </FlexItem>
-    </FlexLayout>
+
+        <VirtualizedList
+          aria-label="ScrollToIndex VirtualizedList example"
+          scrollingApiRef={virtualizedListScrollRef}
+          source={usa_states}
+        />
+      </FlexLayout>
+    </StackLayout>
   );
 };
 
@@ -686,7 +697,7 @@ export const WithTextHighlight: Story<ListProps> = () => {
 
 export const DisableTypeToSelect: Story<ListProps> = () => {
   const handleChange: SelectionChangeHandler = (evt, selected) => {
-    console.log(`selectionChanged ${selected}`);
+    console.log(`selectionChanged`, selected);
   };
 
   return (


### PR DESCRIPTION
- List ref is forwarded to its container HTML element, just like all other components
- Added `scrollingApiRef` for scrolling for both List and VirtualizedList
    - VirtualizedList doesn't scroll beyond buffered items, not planning to cover in this PR 
- Fix empty source passed to VirtualizedList will throw error (fixes #359)
- Fix virtualized list className uitkHighlighted 