### PR TITLE
Fix circular dependencies warning

### DIFF
--- a/.changeset/lovely-readers-talk.md
+++ b/.changeset/lovely-readers-talk.md
@@ -1,0 +1,7 @@
+---
+"@jpmorganchase/uitk-core": patch
+"@jpmorganchase/uitk-icons": patch
+"@jpmorganchase/uitk-lab": patch
+---
+
+Fix circular dependencies warning

--- a/packages/core/src/responsive/useWidth.ts
+++ b/packages/core/src/responsive/useWidth.ts
@@ -1,6 +1,6 @@
 import { RefObject, useCallback, useRef, useState } from "react";
 import { useIsomorphicLayoutEffect } from "../utils";
-import { useResizeObserver, WidthOnly } from "./";
+import { useResizeObserver, WidthOnly } from "./useResizeObserver";
 
 const NONE: string[] = [];
 

--- a/packages/icons/src/icon/createIcon.tsx
+++ b/packages/icons/src/icon/createIcon.tsx
@@ -1,5 +1,5 @@
 import { ForwardedRef, forwardRef, memo, ReactNode } from "react";
-import { Icon, IconProps } from "../icon";
+import { Icon, IconProps } from "./Icon";
 
 /**
  * Private utility.

--- a/packages/lab/src/contact-details/ContactMetadataItem.tsx
+++ b/packages/lab/src/contact-details/ContactMetadataItem.tsx
@@ -3,7 +3,7 @@ import { IconProps } from "@jpmorganchase/uitk-icons";
 import { ComponentType, forwardRef, HTMLAttributes } from "react";
 import { Div } from "../text";
 import { ValueComponentProps } from "./internal";
-import { MailLinkComponent } from "./";
+import { MailLinkComponent } from "./MailLinkComponent";
 
 const withBaseName = makePrefixer("uitkContactMetadataItem");
 


### PR DESCRIPTION
Fixes circular dependencies warning during `yarn build`, excluding grid package which has a lot more interdependencies to be worked on. cc @ararus  