### PR TITLE
Backwards compat styling standardisation 3

### DIFF
--- a/packages/lab/src/metric/Metric.css
+++ b/packages/lab/src/metric/Metric.css
@@ -7,7 +7,8 @@
 
 .uitkMetric-orientation-horizontal {
   flex-direction: row;
-  gap: 16px;
+  gap: var(--metric-horizontal-gap, 16px);
+  margin-top: var(--metric-horizontal-marginTop, 0px);
 }
 
 .uitkMetric-orientation-vertical {
@@ -23,14 +24,14 @@
 }
 
 .backwardsCompat.uitkMetric.uitkMetric-orientation-horizontal {
-  gap: calc(var(--uitk-size-unit) * 2);
+  --metric-horizontal-gap: calc(var(--uitk-size-unit) * 2);
 }
 .backwardsCompat.uitkMetric.uitkMetric-orientation-horizontal.uitkMetric-size-small {
-  margin-top: -4px;
+  --metric-horizontal-marginTop: -4px;
 }
 .backwardsCompat.uitkMetric.uitkMetric-orientation-horizontal.uitkMetric-size-medium {
-  margin-top: -8px;
+  --metric-horizontal-marginTop: -8px;
 }
 .backwardsCompat.uitkMetric.uitkMetric-orientation-horizontal.uitkMetric-size-large {
-  margin-top: -14px;
+  --metric-horizontal-marginTop: -14px;
 }

--- a/packages/lab/src/metric/MetricContent.css
+++ b/packages/lab/src/metric/MetricContent.css
@@ -1,13 +1,15 @@
 .uitkMetricContent {
   display: flex;
   flex-direction: column;
+  margin-top: var(--metric-content-marginTop, 0px);
 }
 
 .uitkMetricContent-value-container {
+  align-items: baseline;
   display: flex;
   flex-direction: row;
-  align-items: baseline;
   gap: calc(var(--uitk-size-unit) / 2);
+  margin-top: var(--metric-content-valueContainer-marginTop, 0px);
 }
 
 .uitkMetric-direction-up .uitkMetricContent-indicator {
@@ -22,6 +24,10 @@
 }
 .uitkMetric-direction-down .uitkMetricContent-subvalue {
   color: var(--uitk-differential-negative-foreground);
+}
+
+.uitkMetricContent-subvalue {
+  margin-top: var(--metric-content-subvalue-marginTop, 0px);
 }
 
 .uitkMetric-align-left .uitkMetricContent {
@@ -45,11 +51,11 @@
   --backwardsCompat-metric-horizontal-medium-subvalue-marginTop: -5px;
   --backwardsCompat-metric-horizontal-large-subvalue-marginTop: -11px;
 
-  --backwardsCompat-metric-vertical-small-value-container-marginTop: 1px;
+  --backwardsCompat-metric-vertical-small-valueContainer-marginTop: 1px;
   --backwardsCompat-metric-vertical-small-subvalue-marginTop: 2px;
-  --backwardsCompat-metric-vertical-medium-value-container-marginTop: 1px;
+  --backwardsCompat-metric-vertical-medium-valueContainer-marginTop: 1px;
   --backwardsCompat-metric-vertical-medium-subvalue-marginTop: 2px;
-  --backwardsCompat-metric-vertical-large-value-container-marginTop: 1px;
+  --backwardsCompat-metric-vertical-large-valueContainer-marginTop: 1px;
   --backwardsCompat-metric-vertical-large-subvalue-marginTop: 1px;
 }
 .uitk-density-medium {
@@ -57,11 +63,11 @@
   --backwardsCompat-metric-horizontal-medium-subvalue-marginTop: -4px;
   --backwardsCompat-metric-horizontal-large-subvalue-marginTop: -10px;
 
-  --backwardsCompat-metric-vertical-small-value-container-marginTop: 2px;
+  --backwardsCompat-metric-vertical-small-valueContainer-marginTop: 2px;
   --backwardsCompat-metric-vertical-small-subvalue-marginTop: 2px;
-  --backwardsCompat-metric-vertical-medium-value-container-marginTop: 2px;
+  --backwardsCompat-metric-vertical-medium-valueContainer-marginTop: 2px;
   --backwardsCompat-metric-vertical-medium-subvalue-marginTop: 2px;
-  --backwardsCompat-metric-vertical-large-value-container-marginTop: 2px;
+  --backwardsCompat-metric-vertical-large-valueContainer-marginTop: 2px;
   --backwardsCompat-metric-vertical-large-subvalue-marginTop: 2px;
 }
 .uitk-density-low {
@@ -69,11 +75,11 @@
   --backwardsCompat-metric-horizontal-medium-subvalue-marginTop: -3px;
   --backwardsCompat-metric-horizontal-large-subvalue-marginTop: -9px;
 
-  --backwardsCompat-metric-vertical-small-value-container-marginTop: 3px;
+  --backwardsCompat-metric-vertical-small-valueContainer-marginTop: 3px;
   --backwardsCompat-metric-vertical-small-subvalue-marginTop: 3px;
-  --backwardsCompat-metric-vertical-medium-value-container-marginTop: 3px;
+  --backwardsCompat-metric-vertical-medium-valueContainer-marginTop: 3px;
   --backwardsCompat-metric-vertical-medium-subvalue-marginTop: 3px;
-  --backwardsCompat-metric-vertical-large-value-container-marginTop: 3px;
+  --backwardsCompat-metric-vertical-large-valueContainer-marginTop: 3px;
   --backwardsCompat-metric-vertical-large-subvalue-marginTop: 3px;
 }
 .uitk-density-touch {
@@ -81,56 +87,56 @@
   --backwardsCompat-metric-horizontal-medium-subvalue-marginTop: -2px;
   --backwardsCompat-metric-horizontal-large-subvalue-marginTop: -8px;
 
-  --backwardsCompat-metric-vertical-small-value-container-marginTop: 4px;
+  --backwardsCompat-metric-vertical-small-valueContainer-marginTop: 4px;
   --backwardsCompat-metric-vertical-small-subvalue-marginTop: 4px;
-  --backwardsCompat-metric-vertical-medium-value-container-marginTop: 4px;
+  --backwardsCompat-metric-vertical-medium-valueContainer-marginTop: 4px;
   --backwardsCompat-metric-vertical-medium-subvalue-marginTop: 4px;
-  --backwardsCompat-metric-vertical-large-value-container-marginTop: 4px;
+  --backwardsCompat-metric-vertical-large-valueContainer-marginTop: 4px;
   --backwardsCompat-metric-vertical-large-subvalue-marginTop: 4px;
 }
 
 /* HORIZONTAL */
 
-/* Size small */
-.backwardsCompat.uitkMetric.uitkMetric-orientation-horizontal.uitkMetric-size-small .uitkMetricContent-subvalue {
-  margin-top: var(--backwardsCompat-metric-horizontal-small-subvalue-marginTop);
+/* Size S */
+.backwardsCompat.uitkMetric-orientation-horizontal.uitkMetric-size-small .uitkMetricContent-subvalue {
+  --metric-content-subvalue-marginTop: var(--backwardsCompat-metric-horizontal-small-subvalue-marginTop);
 }
 
-/* Size medium */
-.backwardsCompat.uitkMetric.uitkMetric-orientation-horizontal.uitkMetric-size-medium .uitkMetricContent-subvalue {
-  margin-top: var(--backwardsCompat-metric-horizontal-medium-subvalue-marginTop);
+/* Size M */
+.backwardsCompat.uitkMetric-orientation-horizontal.uitkMetric-size-medium .uitkMetricContent-subvalue {
+  --metric-content-subvalue-marginTop: var(--backwardsCompat-metric-horizontal-medium-subvalue-marginTop);
 }
 
-/* Size large */
-.backwardsCompat.uitkMetric.uitkMetric-orientation-horizontal.uitkMetric-size-large .uitkMetricContent {
-  margin-top: -1px;
+/* Size L */
+.backwardsCompat.uitkMetric-orientation-horizontal.uitkMetric-size-large .uitkMetricContent {
+  --metric-content-marginTop: -1px;
 }
-.backwardsCompat.uitkMetric.uitkMetric-orientation-horizontal.uitkMetric-size-large .uitkMetricContent-subvalue {
-  margin-top: var(--backwardsCompat-metric-horizontal-large-subvalue-marginTop);
+.backwardsCompat.uitkMetric-orientation-horizontal.uitkMetric-size-large .uitkMetricContent-subvalue {
+  --metric-content-subvalue-marginTop: var(--backwardsCompat-metric-horizontal-large-subvalue-marginTop);
 }
 
 /* VERTICAL */
 
-/* Size small */
-.backwardsCompat.uitkMetric.uitkMetric-orientation-vertical.uitkMetric-size-small .uitkMetricContent-value-container {
-  margin-top: var(--backwardsCompat-metric-vertical-small-value-container-marginTop);
+/* Size S */
+.backwardsCompat.uitkMetric-orientation-vertical.uitkMetric-size-small .uitkMetricContent-value-container {
+  --metric-content-valueContainer-marginTop: var(--backwardsCompat-metric-vertical-small-valueContainer-marginTop);
 }
-.backwardsCompat.uitkMetric.uitkMetric-orientation-vertical.uitkMetric-size-small .uitkMetricContent-subvalue {
-  margin-top: var(--backwardsCompat-metric-vertical-small-subvalue-marginTop);
-}
-
-/* Size medium */
-.backwardsCompat.uitkMetric.uitkMetric-orientation-vertical.uitkMetric-size-medium .uitkMetricContent-value-container {
-  margin-top: var(--backwardsCompat-metric-vertical-medium-value-container-marginTop);
-}
-.backwardsCompat.uitkMetric.uitkMetric-orientation-vertical.uitkMetric-size-medium .uitkMetricContent-subvalue {
-  margin-top: var(--backwardsCompat-metric-vertical-medium-subvalue-marginTop);
+.backwardsCompat.uitkMetric-orientation-vertical.uitkMetric-size-small .uitkMetricContent-subvalue {
+  --metric-content-subvalue-marginTop: var(--backwardsCompat-metric-vertical-small-subvalue-marginTop);
 }
 
-/* Size large */
-.backwardsCompat.uitkMetric.uitkMetric-orientation-vertical.uitkMetric-size-large .uitkMetricContent-value-container {
-  margin-top: var(--backwardsCompat-metric-vertical-large-value-container-marginTop);
+/* Size M */
+.backwardsCompat.uitkMetric-orientation-vertical.uitkMetric-size-medium .uitkMetricContent-value-container {
+  --metric-content-valueContainer-marginTop: var(--backwardsCompat-metric-vertical-medium-valueContainer-marginTop);
 }
-.backwardsCompat.uitkMetric.uitkMetric-orientation-vertical.uitkMetric-size-large .uitkMetricContent-subvalue {
-  margin-top: var(--backwardsCompat-metric-vertical-large-subvalue-marginTop);
+.backwardsCompat.uitkMetric-orientation-vertical.uitkMetric-size-medium .uitkMetricContent-subvalue {
+  --metric-content-subvalue-marginTop: var(--backwardsCompat-metric-vertical-medium-subvalue-marginTop);
+}
+
+/* Size L */
+.backwardsCompat.uitkMetric-orientation-vertical.uitkMetric-size-large .uitkMetricContent-value-container {
+  --metric-content-valueContainer-marginTop: var(--backwardsCompat-metric-vertical-large-valueContainer-marginTop);
+}
+.backwardsCompat.uitkMetric-orientation-vertical.uitkMetric-size-large .uitkMetricContent-subvalue {
+  --metric-content-subvalue-marginTop: var(--backwardsCompat-metric-vertical-large-subvalue-marginTop);
 }

--- a/packages/lab/src/progress/CircularProgress/CircularProgress.css
+++ b/packages/lab/src/progress/CircularProgress/CircularProgress.css
@@ -1,4 +1,6 @@
 .uitkCircularProgress {
+  --circularProgress-gradient-color: var(--uitk-measured-fill);
+
   color: var(--uitk-text-primary-foreground);
   display: inline-flex;
   position: relative;
@@ -51,7 +53,7 @@
 
 .uitkCircularProgress-gradientStart,
 .uitkCircularProgress-gradientStop {
-  stop-color: var(--uitk-measured-fill);
+  stop-color: var(--uitkCircularProgress-gradient-color, var(--circularProgress-gradient-color));
 }
 
 .uitkCircularProgress-container {
@@ -110,9 +112,9 @@
 /* TK1 Backwards compatibility */
 
 .backwardsCompat.uitkCircularProgress .uitkCircularProgress-gradientStart {
-  stop-color: var(--backwardsCompat-measured-fill-startColor);
+  --circularProgress-gradient-color: var(--backwardsCompat-measured-fill-startColor);
 }
 
 .backwardsCompat.uitkCircularProgress .uitkCircularProgress-gradientStop {
-  stop-color: var(--backwardsCompat-measured-fill-stopColor);
+  --circularProgress-gradient-color: var(--backwardsCompat-measured-fill-stopColor);
 }

--- a/packages/lab/src/slider/Slider.css
+++ b/packages/lab/src/slider/Slider.css
@@ -208,6 +208,8 @@
   text-overflow: ellipsis;
 }
 
+/* TK1 Backwards compatibility */
+
 .backwardsCompat.uitkSlider {
   --slider-label-fontSize: var(--backwardsCompat-text-caption-fontSize);
 }

--- a/packages/lab/src/spinner/Spinner.css
+++ b/packages/lab/src/spinner/Spinner.css
@@ -1,11 +1,14 @@
+
 .uitkSvgSpinner-gradientStop1,
 .uitkSvgSpinner-gradientStop2,
 .uitkSvgSpinner-gradientStop3,
 .uitkSvgSpinner-gradientStop4 {
-  stop-color: var(--uitk-measured-fill);
+  stop-color: var(--uitkSpinner-gradient-color, var(--spinner-gradient-color));
 }
 
 .uitkSvgSpinner {
+  --spinner-gradient-color: var(--uitk-measured-fill);
+  
   position: relative;
 }
 
@@ -43,12 +46,13 @@
 }
 
 /* TK1 Backwards compatibility */
+
 .backwardsCompat.uitkSvgSpinner .uitkSvgSpinner-gradientStop1,
 .backwardsCompat.uitkSvgSpinner .uitkSvgSpinner-gradientStop3 {
-  stop-color: var(--backwardsCompat-measured-fill-stopColor);
+  --spinner-gradient-color: var(--backwardsCompat-measured-fill-stopColor);
 }
 
 .backwardsCompat.uitkSvgSpinner .uitkSvgSpinner-gradientStop2,
 .backwardsCompat.uitkSvgSpinner .uitkSvgSpinner-gradientStop4 {
-  stop-color: var(--backwardsCompat-measured-fill-startColor);
+  --spinner-gradient-color: var(--backwardsCompat-measured-fill-startColor);
 }

--- a/packages/lab/src/spinner/Spinner.css
+++ b/packages/lab/src/spinner/Spinner.css
@@ -1,4 +1,3 @@
-
 .uitkSvgSpinner-gradientStop1,
 .uitkSvgSpinner-gradientStop2,
 .uitkSvgSpinner-gradientStop3,
@@ -8,7 +7,7 @@
 
 .uitkSvgSpinner {
   --spinner-gradient-color: var(--uitk-measured-fill);
-  
+
   position: relative;
 }
 

--- a/packages/lab/src/spinner/svgSpinners/SpinnerMedium.tsx
+++ b/packages/lab/src/spinner/svgSpinners/SpinnerMedium.tsx
@@ -2,6 +2,7 @@ import { SVGAttributes } from "react";
 
 const baseName = "uitkSvgSpinner";
 
+// Note: the structure here is mainly for backwards compatibility where 2 colors were used
 export const SpinnerMedium = (props: SVGAttributes<SVGSVGElement>) => (
   <svg className={`${baseName}-spinner`} viewBox="0 0 24 24" {...props}>
     <defs>
@@ -12,7 +13,7 @@ export const SpinnerMedium = (props: SVGAttributes<SVGSVGElement>) => (
         y1="75.6597923%"
         y2="75.6597923%"
       >
-        <stop className={`${baseName}-gradientStop1`} offset="0%" />
+        <stop className={`${baseName}-gradientStop1`} offset="0%" />  
         <stop className={`${baseName}-gradientStop2`} offset="100%" />
       </linearGradient>
       <linearGradient

--- a/packages/lab/src/spinner/svgSpinners/SpinnerMedium.tsx
+++ b/packages/lab/src/spinner/svgSpinners/SpinnerMedium.tsx
@@ -13,7 +13,7 @@ export const SpinnerMedium = (props: SVGAttributes<SVGSVGElement>) => (
         y1="75.6597923%"
         y2="75.6597923%"
       >
-        <stop className={`${baseName}-gradientStop1`} offset="0%" />  
+        <stop className={`${baseName}-gradientStop1`} offset="0%" />
         <stop className={`${baseName}-gradientStop2`} offset="100%" />
       </linearGradient>
       <linearGradient


### PR DESCRIPTION
Part of CSS clean up (#377)

 For backwards compat tokens, standardise by:
- If density/theme dependent, creating —backwardsCompat- token
- Then set the local token of what needs adjusting (if exists, else the raw attr) within .backwardsCompat class to the backwardsCompat token defined or otherwise the necessary value

Components in this PR: 

> Spinner
> Slider
> CircularProgress
> Metric

See #428 #441 