### PR TITLE
FormField: detect not fully supported children inputs

### DIFF
--- a/packages/core/src/__tests__/__e2e__/form-field/FormField.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/form-field/FormField.cy.tsx
@@ -15,6 +15,44 @@ describe("GIVEN an Input", () => {
     });
   });
 
+  describe("WHEN there is a help text", () => {
+    it("THEN it should render help text", () => {
+      cy.mount(
+        <FormField label="Test Form Field" helperText="Here's some help">
+          <Input defaultValue="Value" />
+        </FormField>
+      );
+      cy.findByText("Here's some help").should("exist");
+    });
+    describe("WHEN help text is placed in tooltip", () => {
+      it("THEN it should render help text in a tooltip", () => {
+        cy.mount(
+          <FormField
+            label="Test Form Field"
+            helperText="Here's some help"
+            helperTextPlacement="tooltip"
+          >
+            <Input defaultValue="Value" />
+          </FormField>
+        );
+        cy.findByLabelText("Test Form Field").realHover();
+        cy.findByRole("tooltip").should("be.visible");
+        cy.findByRole("tooltip").should("have.text", "Here's some help");
+      });
+    });
+  });
+
+  // describe("WHEN the user adds low emphasis class", () => {
+  //   it("THEN it should render error icon", () => {
+  //     cy.mount(
+  //       <FormField label="Low emphasis" className="uitkLowEmphasis">
+  //         <Input defaultValue="Value" />
+  //       </FormField>
+  //     );
+  //     cy.findByRole("textbox").focus();
+  //   });
+  // });
+
   describe("WHEN validation status is error", () => {
     it("THEN it should render error icon", () => {
       cy.mount(
@@ -23,6 +61,20 @@ describe("GIVEN an Input", () => {
         </FormField>
       );
       cy.findByTestId("ErrorIndicatorIcon").should(
+        "have.class",
+        "uitkFormActivationIndicator-icon"
+      );
+    });
+  });
+
+  describe("WHEN validation status is warning", () => {
+    it("THEN it should render warning icon", () => {
+      cy.mount(
+        <FormField label="Error validation status" validationStatus="warning">
+          <Input defaultValue="Value" />
+        </FormField>
+      );
+      cy.findByTestId("WarningIndicatorIcon").should(
         "have.class",
         "uitkFormActivationIndicator-icon"
       );
@@ -63,6 +115,22 @@ describe("GIVEN an Input", () => {
 
       cy.findByRole("textbox").focus();
       cy.checkAxeComponent();
+    });
+    describe("WHEN disableFocusRing is true", () => {
+      it("SHOULD not put a focus ring on form field or input", () => {
+        cy.mount(
+          <FormField label="Warning validation status" disableFocusRing>
+            <Input defaultValue="Value" data-testid="test-id-1" />
+          </FormField>
+        );
+
+        cy.findByRole("textbox").focus();
+        cy.findByTestId("test-id-1").should(
+          "not.have.class",
+          "uitkInput-focused"
+        );
+        cy.get(".uitkFormField-focused").should("not.exist");
+      });
     });
   });
 });

--- a/packages/core/src/form-field-context/FormFieldContext.ts
+++ b/packages/core/src/form-field-context/FormFieldContext.ts
@@ -1,5 +1,5 @@
 import { Dispatch, FocusEventHandler, RefObject, SetStateAction } from "react";
-import { useA11yValueValue } from "../form-field";
+import { useA11yValueValue, FormFieldValidationStatus } from "../form-field";
 import { createContext } from "../utils";
 export interface FormFieldContextValue {
   inFormField: true;
@@ -9,6 +9,7 @@ export interface FormFieldContextValue {
   setFocused: Dispatch<SetStateAction<boolean>>;
   onBlur: FocusEventHandler<HTMLElement>;
   onFocus: FocusEventHandler<HTMLElement>;
+  validationStatus?: FormFieldValidationStatus;
 }
 
 export const FormFieldContext = createContext(

--- a/packages/core/src/form-field/FormActivationIndicator.tsx
+++ b/packages/core/src/form-field/FormActivationIndicator.tsx
@@ -3,6 +3,7 @@ import { makePrefixer } from "../utils";
 import { FormFieldProps } from "./FormField";
 
 import "./FormActivationIndicator.css";
+import { useFormFieldProps } from "../form-field-context";
 
 const ErrorIndicatorIcon = (props: SVGAttributes<SVGSVGElement>) => {
   return (
@@ -54,15 +55,15 @@ export interface FormActivationIndicatorProps
 export const FormActivationIndicator: React.FC<
   FormActivationIndicatorProps
 > = ({ hasIcon, validationStatus }: FormActivationIndicatorProps) => {
-  const rootClass = "uitkFormActivationIndicator";
+  const { validationStatus: formFieldValidationStatus } = useFormFieldProps();
 
   return (
     <div className={withBaseName()}>
       <div className={withBaseName("bar")}>
         {hasIcon && validationStatus && (
           <ActivationIndicatorIcon
-            className={`${rootClass}-icon`}
-            validationStatus={validationStatus}
+            className="uitkFormActivationIndicator-icon"
+            validationStatus={validationStatus || formFieldValidationStatus}
           />
         )}
       </div>

--- a/packages/core/src/form-field/FormField.css
+++ b/packages/core/src/form-field/FormField.css
@@ -18,8 +18,6 @@
   --formField-activationIndicator-style: var(--uitk-editable-borderStyle);
   --formField-background: var(--uitk-editable-background-medium);
   --formField-focused-outlineColor: var(--uitk-focused-outlineColor);
-  /* Set to 0 until helper text class provided */
-  --formField-helperText-height: 0px;
 }
 
 .uitkEmphasisLow.uitkFormField {
@@ -32,7 +30,6 @@
 
 .uitkFormField {
   border: 0;
-  display: inline-grid;
   font-size: var(--uitkFormField-fontSize, var(--uitk-text-fontSize));
   margin: var(--uitkFormField-margin, 0);
   padding: 0;
@@ -43,7 +40,7 @@
 }
 
 /* Class applied to the root element on hover */
-.uitkFormField:not(.uitkFormField-readOnly):not(.uitkFormField-warning):not(.uitkFormField-error):not(.uitkFormField-disabled):not(.uitkFormField-focused):hover {
+.uitkFormField:hover {
   --formField-activationIndicator-color: var(--uitk-editable-borderColor-hover);
   --formField-activationIndicator-size: var(--uitk-editable-borderWidth-hover);
   --formField-activationIndicator-style: var(--uitk-editable-borderStyle-hover);
@@ -53,7 +50,9 @@
 
 /* Class applied to the root element on focus */
 .uitkFormField-focused,
-.uitkFormField-lowFocused {
+.uitkFormField-lowFocused,
+.uitkFormField-focused:hover,
+.uitkFormField-lowFocused:hover {
   --formField-activationIndicator-color: var(--uitk-editable-borderColor-active);
   --formField-activationIndicator-size: var(--uitk-editable-borderWidth-active);
   --formField-activationIndicator-style: var(--uitk-editable-borderStyle-active);
@@ -64,21 +63,16 @@
 /* Class applied when helper text is provided */
 .uitkFormField-withHelperText {
   --formField-helperText-marginTop: var(--formField-helperText-marginTop-default);
-  --formField-activationIndicator-offsetBottom: calc(var(--formField-helperText-marginTop) + var(--uitkFormField-helperText-lineHeight, var(--formField-helperText-height)));
 }
 
 /* Class applied if `fullWidth={true}` and helper text is provided */
 .uitkFormField-fullWidth.uitkFormField-withHelperText {
   --formField-helperText-marginTop: var(--formField-helperText-marginTop-fullWidth);
-  --formField-activationIndicator-offsetBottom: calc(var(--formField-helperText-marginTop-fullWidth) + var(--uitkFormField-helperText-lineHeight, var(--formField-helperText-height)));
 }
 
 /* Class applied when helper text is provided */
 .uitkFormField-withHelperText {
   --formField-helperText-fontSize: var(--uitkFormField-helperText-fontSize, var(--uitk-text-fontSize));
-  --formField-helperText-baseHeight: calc(var(--uitk-text-base-lineHeight) * var(--formField-helperText-fontSize));
-  --formField-helperText-calculatedHeight: max(var(--uitk-text-help-minHeight), var(--formField-helperText-baseHeight));
-  --formField-helperText-height: calc(var(--formField-helperText-calculatedHeight) + var(--formField-helperText-marginTop));
 }
 
 /* Class applied to the root element if `fillWidth={true}` */
@@ -120,9 +114,7 @@
   --formField-label-marginTop: var(--uitk-size-unit);
   --formField-label-paddingLeft: 0px;
   --formField-label-paddingRight: calc(0.75 * var(--uitk-size-unit));
-
   align-self: start;
-  grid-template-columns: auto 1fr;
 }
 
 /* Class applied to the root element if `labelPlacement="top"` or labelPlacement omitted (default is 'top') */
@@ -131,10 +123,6 @@
   --formField-label-marginTop: 0;
   --formField-label-paddingLeft: var(--uitk-size-unit);
   --formField-label-paddingRight: var(--uitk-size-unit);
-  /* Uses density invariant value unless helper text provided */
-  --formField-background-offset-height: calc(var(--formField-helperText-marginTop, 0px) + var(--uitkFormField-helperText-lineHeight, var(--formField-helperText-height)));
-
-  background: linear-gradient(to top, transparent var(--formField-background-offset-height), var(--uitkFormField-background, var(--formField-background)) var(--formField-background-offset-height));
 }
 
 .uitkFormField-notFullySupportedInput {
@@ -148,81 +136,31 @@
   --uitkFormField-helperText-paddingRight: 0;
 }
 
-/* Class applied if `labelPlacement="top"` and helper text is provided */
-.uitkFormField-labelTop.uitkFormField-withHelperText {
-  /* Uses density aware value from FormHelperText */
-  --formField-background-offset-height: var(--formField-helperText-background-offset-height);
-}
-
-.uitkFormField > * {
-  grid-column-start: 1;
-  grid-column-end: 2;
-  grid-row-start: 2;
-  grid-row-end: 3;
-}
-
-.uitkFormField-labelLeft > * {
-  grid-row-start: 1;
-  grid-row-end: 2;
-}
-
-.uitkFormField > .uitkFormLabel {
-  grid-row-start: 1;
-  grid-row-end: 2;
-}
-
-.uitkFormField > .uitkFormActivationIndicator {
-  grid-row-start: 3;
-  grid-row-end: 4;
-}
-
-.uitkFormField > .uitkFormFieldHelperText {
-  grid-row-start: 4;
-  grid-row-end: 5;
-}
-
-.uitkFormField-labelLeft > .uitkFormLabel ~ * {
-  grid-column-start: 2;
-  grid-column-end: 2;
-}
-
 /* Class applied if `readOnly={true}"` */
 .uitkFormField-readOnly {
   --formField-activationIndicator-color: var(--uitk-editable-borderColor-readonly);
 }
 
-/* Class applied on focus with `labelTop={true}` and no helper text provided */
-.uitkFormField:not(.uitkFormField-withHelperText):not(.uitkFormField-labelLeft).uitkFormField-focused:before {
-  content: " ";
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: var(--uitkFormField-helperText-lineHeight, var(--formField-helperText-height, 0px));
-  outline-color: var(--formField-focused-outlineColor);
-  outline-style: var(--uitk-focused-outlineStyle);
-  outline-width: var(--uitk-focused-outlineWidth);
+.uitkFormField-labelLeft .uitkFormField-inner {
+  display: flex;
 }
 
-/* Class applied on focus with `labelTop={true}` and helper text provided */
-.uitkFormField-withHelperText:not(.uitkFormField-labelLeft).uitkFormField-focused:before {
-  content: " ";
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: var(--formField-helperText-height, 0px);
-  outline-color: var(--formField-focused-outlineColor);
-  outline-style: var(--uitk-focused-outlineStyle);
-  outline-width: var(--uitk-focused-outlineWidth);
+.uitkFormField-labelLeft .uitkFormLabel {
+  min-width: min-content;
 }
 
-.uitkFormField-labelLeft.uitkFormField-focused:before {
-  content: none;
+.uitkFormField-labelLeft.uitkFormField-focused * {
+  outline: none;
 }
 
-/* Class applied on focus with `labelLeft={true}` */
-.uitkFormField-labelLeft.uitkFormField-focused > *:before {
+.uitkFormField-inner,
+.uitkFormField-inputWrapper {
+  position: relative;
+}
+
+/* Class applied on focus */
+.uitkFormField-focused.uitkFormField-labelTop .uitkFormField-inner:before,
+.uitkFormField-focused.uitkFormField-labelLeft .uitkFormField-inputWrapper:before {
   content: " ";
   position: absolute;
   top: 0;
@@ -232,35 +170,14 @@
   outline-color: var(--formField-focused-outlineColor);
   outline-style: var(--uitk-focused-outlineStyle);
   outline-width: var(--uitk-focused-outlineWidth);
-  z-index: -1;
 }
 
-.uitkFormField-labelLeft.uitkFormField-focused > :is(.uitkFormActivationIndicator, .uitkFormFieldHelperText, .uitkFormLabel):before {
-  content: none;
+.uitkFormField.uitkFormField-labelLeft .uitkFormField-inputWrapper {
+  background-color: var(--uitkFormField-background, var(--formField-background));
 }
 
-.uitkFormField-labelLeft.uitkFormField-focused {
-  outline: none;
-}
-
-.uitkFormField-labelLeft.uitkFormField-focused > :is(.uitkFormField-activationIndicator, .uitkFormField-helperText, .uitkFormLabel):before {
-  content: none;
-}
-
-.uitkFormField-labelLeft.uitkFormField-focused .uitkFormLabel + * {
-  outline: none;
-}
-
-.uitkEmphasisLow.uitkFormField.uitkFormField-labelLeft > .uitkFormLabel ~ * {
-  background: var(--uitkFormField-background, var(--formField-background));
-}
-
-.uitkEmphasisMedium.uitkFormField > :not(.uitkFormLabel):first-child {
-  background: var(--uitkFormField-background, var(--formField-background));
-}
-
-.uitkFormField-labelLeft > .uitkFormLabel ~ :not(.uitkFormFieldHelperText) {
-  background: var(--uitkFormField-background, var(--formField-background));
+.uitkFormField.uitkFormField-labelTop .uitkFormField-inner {
+  background-color: var(--uitkFormField-background, var(--formField-background));
 }
 
 /* TK1 backwards compat styling */

--- a/packages/core/src/form-field/FormField.css
+++ b/packages/core/src/form-field/FormField.css
@@ -137,6 +137,17 @@
   background: linear-gradient(to top, transparent var(--formField-background-offset-height), var(--uitkFormField-background, var(--formField-background)) var(--formField-background-offset-height));
 }
 
+.uitkFormField-notFullySupportedInput {
+  --formField-label-marginBottom: calc(2 * var(--formField-label-top-marginBottom));
+  --formField-label-paddingLeft: 0;
+  --formField-label-paddingRight: 0;
+}
+
+.uitkFormField-notFullySupportedInput .uitkFormFieldHelperText {
+  --uitkFormField-helperText-paddingLeft: 0;
+  --uitkFormField-helperText-paddingRight: 0;
+}
+
 /* Class applied if `labelPlacement="top"` and helper text is provided */
 .uitkFormField-labelTop.uitkFormField-withHelperText {
   /* Uses density aware value from FormHelperText */

--- a/packages/core/src/form-field/FormField.tsx
+++ b/packages/core/src/form-field/FormField.tsx
@@ -25,6 +25,9 @@ import { NecessityIndicatorOptions } from "./NecessityIndicator";
 import { StatusIndicatorProps } from "./StatusIndicator";
 
 import "./FormField.css";
+import { Checkbox, CheckboxGroup } from "../checkbox";
+import { RadioButton, RadioButtonGroup } from "../radio-button";
+import { Switch } from "../switch";
 
 export type FormFieldLabelPlacement = "top" | "left";
 export type FormFieldHelperTextPlacement = "bottom" | "tooltip";
@@ -251,6 +254,13 @@ export const FormField = forwardRef(
       disabled: !tooltipHelperText,
     });
 
+    const isInputNotFullySupported =
+      !children ||
+      [Checkbox, CheckboxGroup, RadioButton, RadioButtonGroup, Switch].includes(
+        // @ts-ignore
+        children.type
+      );
+
     const { ref: triggerRef, ...triggerProps } = getTriggerProps({
       className: cx(
         withBaseName(),
@@ -263,7 +273,8 @@ export const FormField = forwardRef(
           [withBaseName(focusClass)]: states.focused,
           [withBaseName("labelTop")]: labelTop,
           [withBaseName("labelLeft")]: labelLeft,
-          [withBaseName(`withHelperText`)]: inlineHelperText,
+          [withBaseName("withHelperText")]: inlineHelperText,
+          [withBaseName("notFullySupportedInput")]: isInputNotFullySupported,
         },
         className
       ),
@@ -303,10 +314,11 @@ export const FormField = forwardRef(
               />
             )}
             {children}
-            <ActivationIndicatorComponent
-              hasIcon={!hasStatusIndicator}
-              validationStatus={validationStatus}
-            />
+            {isInputNotFullySupported ? null : (
+              <ActivationIndicatorComponent
+                hasIcon={!hasStatusIndicator}
+                validationStatus={validationStatus}
+              />
             {renderHelperText && (
               <HelperTextComponent
                 helperText={helperText}

--- a/packages/core/src/form-field/FormField.tsx
+++ b/packages/core/src/form-field/FormField.tsx
@@ -262,22 +262,6 @@ export const FormField = forwardRef(
       );
 
     const { ref: triggerRef, ...triggerProps } = getTriggerProps({
-      className: cx(
-        withBaseName(),
-        {
-          [withBaseName("disabled")]: disabled,
-          [withBaseName("readOnly")]: readOnly,
-          [withBaseName("warning")]: isWarning,
-          [withBaseName("error")]: isError,
-          [withBaseName("fullWidth")]: fullWidth,
-          [withBaseName(focusClass)]: states.focused,
-          [withBaseName("labelTop")]: labelTop,
-          [withBaseName("labelLeft")]: labelLeft,
-          [withBaseName("withHelperText")]: inlineHelperText,
-          [withBaseName("notFullySupportedInput")]: isInputNotFullySupported,
-        },
-        className
-      ),
       ...eventHandlers,
       ...restProps,
     });
@@ -285,9 +269,38 @@ export const FormField = forwardRef(
     const handleTriggerRef = useForkRef(triggerRef, rootRef);
     const handleRef = useForkRef(handleTriggerRef, ref);
 
+    const helperTextComponent = (
+      <HelperTextComponent
+        helperText={helperText}
+        helperTextPlacement={helperTextPlacement}
+        {...HelperTextProps}
+        id={helperTextId}
+      />
+    );
+
     return (
       <>
-        <div ref={handleRef} {...triggerProps}>
+        <div
+          ref={handleRef}
+          {...triggerProps}
+          className={cx(
+            withBaseName(),
+            {
+              [withBaseName("disabled")]: disabled,
+              [withBaseName("readOnly")]: readOnly,
+              [withBaseName("warning")]: isWarning,
+              [withBaseName("error")]: isError,
+              [withBaseName("fullWidth")]: fullWidth,
+              [withBaseName(focusClass)]: states.focused,
+              [withBaseName("labelTop")]: labelTop,
+              [withBaseName("labelLeft")]: labelLeft,
+              [withBaseName("withHelperText")]: inlineHelperText,
+              [withBaseName("notFullySupportedInput")]:
+                isInputNotFullySupported,
+            },
+            className
+          )}
+        >
           <FormFieldContext.Provider
             value={{
               ...states,
@@ -296,38 +309,35 @@ export const FormField = forwardRef(
               a11yProps: a11yValue,
               inFormField: true,
               ref: rootRef,
+              validationStatus,
             }}
           >
-            {hasLabel && (
-              <LabelComponent
-                {...LabelProps}
-                validationStatus={validationStatus}
-                hasStatusIndicator={hasStatusIndicator}
-                StatusIndicatorProps={StatusIndicatorProps}
-                className={LabelProps.className}
-                label={label}
-                disabled={disabled}
-                readOnly={readOnly}
-                required={required}
-                tooltipText={helperText}
-                id={labelId}
-              />
-            )}
-            {children}
-            {isInputNotFullySupported ? null : (
-              <ActivationIndicatorComponent
-                hasIcon={!hasStatusIndicator}
-                validationStatus={validationStatus}
-              />
-            )}
-            {renderHelperText && (
-              <HelperTextComponent
-                helperText={helperText}
-                helperTextPlacement={helperTextPlacement}
-                {...HelperTextProps}
-                id={helperTextId}
-              />
-            )}
+            <div className={withBaseName("inner")}>
+              {hasLabel && (
+                <LabelComponent
+                  {...LabelProps}
+                  validationStatus={validationStatus}
+                  hasStatusIndicator={hasStatusIndicator}
+                  StatusIndicatorProps={StatusIndicatorProps}
+                  className={LabelProps.className}
+                  label={label}
+                  disabled={disabled}
+                  readOnly={readOnly}
+                  required={required}
+                  tooltipText={helperText}
+                  id={labelId}
+                />
+              )}
+              <div>
+                <div className={withBaseName("inputWrapper")}>{children}</div>
+                {renderHelperText &&
+                  labelPlacement === "left" &&
+                  helperTextComponent}
+              </div>
+            </div>
+            {renderHelperText &&
+              labelPlacement === "top" &&
+              helperTextComponent}
           </FormFieldContext.Provider>
         </div>
         <Tooltip {...getTooltipProps({ title: helperText })} />

--- a/packages/core/src/form-field/FormField.tsx
+++ b/packages/core/src/form-field/FormField.tsx
@@ -319,6 +319,7 @@ export const FormField = forwardRef(
                 hasIcon={!hasStatusIndicator}
                 validationStatus={validationStatus}
               />
+            )}
             {renderHelperText && (
               <HelperTextComponent
                 helperText={helperText}

--- a/packages/core/src/form-field/FormHelperText.css
+++ b/packages/core/src/form-field/FormHelperText.css
@@ -2,29 +2,21 @@
 .uitk-density-high {
   --formField-helperText-marginTop-default: 2px;
   --formField-helperText-marginTop-fullWidth: 3px;
-
-  --formField-helperText-background-offset-height: 17px;
 }
 .uitk-density-medium {
   --formField-helperText-marginTop-default: 2px;
   --formField-helperText-marginTop-fullWidth: 3px;
   --formField-helperText-transform: translate(0, 2px);
-
-  --formField-helperText-background-offset-height: 19px;
 }
 .uitk-density-touch {
   --formField-helperText-marginTop-default: 8px;
   --formField-helperText-marginTop-fullWidth: 5px;
   --formField-helperText-transform: translate(0, -3px);
-
-  --formField-helperText-background-offset-height: 21px;
 }
 .uitk-density-low {
   --formField-helperText-marginTop-default: 4px;
   --formField-helperText-marginTop-fullWidth: 5px;
   --formField-helperText-transform: translate(0, 1px);
-
-  --formField-helperText-background-offset-height: 21px;
 }
 
 /* Class applied if `fullWidth={true}` */

--- a/packages/core/src/form-field/FormHelperText.tsx
+++ b/packages/core/src/form-field/FormHelperText.tsx
@@ -14,20 +14,13 @@ export const FormHelperText = <E extends React.ElementType = "p">({
   helperTextPlacement,
   ...restProps
 }: FormHelperTextProps<E>) => {
-  if (helperText) {
-    if (helperTextPlacement === "bottom") {
-      return (
-        <p className={`uitkFormFieldHelperText`} {...restProps}>
-          {helperText}
-        </p>
-      );
-    } else if (helperTextPlacement === "tooltip") {
-      console.warn("helperTextPlacement tooltip has not yet implemented");
-      return null;
-    } else {
-      return null;
-    }
-  } else {
-    return null;
-  }
+  if (!helperText) return null;
+
+  if (helperTextPlacement !== "bottom") return null;
+
+  return (
+    <p className={`uitkFormFieldHelperText`} {...restProps}>
+      {helperText}
+    </p>
+  );
 };

--- a/packages/core/src/input/Input.tsx
+++ b/packages/core/src/input/Input.tsx
@@ -20,6 +20,8 @@ import { makePrefixer, useControlled, useForkRef } from "../utils";
 import { useCursorOnFocus } from "./useCursorOnFocus";
 
 import "./Input.css";
+import { FormActivationIndicator } from "../form-field/FormActivationIndicator";
+import { FormFieldValidationStatus } from "../form-field";
 
 const withBaseName = makePrefixer("uitkInput");
 
@@ -56,6 +58,15 @@ export interface InputProps
    * e.g. [0,1] will highlight the first character.
    */
   highlightOnFocus?: boolean | number[];
+  /**
+   * Whether to show the StatusIndicator component for validation states.
+   * Defaults to false.
+   */
+  hasStatusIndicator?: boolean;
+  /**
+   * The state for the Input: Must be one of: 'error'|'warning'|undefined
+   */
+  validationStatus?: FormFieldValidationStatus;
   /**
    * The HTML element to render the Input, e.g. 'input', a custom React component.
    */
@@ -133,6 +144,8 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
     emptyReadOnlyMarker = "—",
     endAdornment,
     highlightOnFocus,
+    hasStatusIndicator = false,
+    validationStatus,
     id,
     inputComponent: InputComponent = "input",
     inputProps: inputPropsProp,
@@ -167,6 +180,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
     } = {},
     setFocused: setFormFieldFocused,
     inFormField,
+    validationStatus: formFieldValidationStatus,
   } = useFormFieldProps();
 
   const [focused, setFocused] = useState(false);
@@ -237,48 +251,56 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
   };
 
   return (
-    <div
-      className={cx(
-        withBaseName(),
-        {
-          [withBaseName(`${textAlign}TextAlign`)]: textAlign,
-          [withBaseName("formField")]: inFormField,
-          [withBaseName("focused")]: focused && !inFormField,
-          [withBaseName("disabled")]: isDisabled,
-          [withBaseName("inputAdornedStart")]: startAdornment,
-          [withBaseName("inputAdornedEnd")]: endAdornment,
-        },
-        classNameProp
-      )}
-      style={style}
-      {...other}
-    >
-      {startAdornment && (
-        <div className={withBaseName("prefixContainer")}>{startAdornment}</div>
-      )}
-      <InputComponent
-        type={type}
-        id={id}
-        {...inputProps}
-        className={cx(withBaseName("input"), inputProps?.className)}
-        disabled={isDisabled}
-        ref={handleRef}
-        value={value}
-        onBlur={handleBlur}
-        onChange={handleChange}
-        onKeyDown={onKeyDown}
-        onKeyUp={onKeyUp}
-        onFocus={handleFocus}
-        onMouseDown={handleMouseDown}
-        onMouseUp={handleMouseUp}
-        onMouseMove={handleMouseMove}
-        readOnly={isReadOnly}
+    <div>
+      <div
+        className={cx(
+          withBaseName(),
+          {
+            [withBaseName(`${textAlign}TextAlign`)]: textAlign,
+            [withBaseName("formField")]: inFormField,
+            [withBaseName("focused")]: focused && !inFormField,
+            [withBaseName("disabled")]: isDisabled,
+            [withBaseName("inputAdornedStart")]: startAdornment,
+            [withBaseName("inputAdornedEnd")]: endAdornment,
+          },
+          classNameProp
+        )}
+        style={style}
+        {...other}
+      >
+        {startAdornment && (
+          <div className={withBaseName("prefixContainer")}>
+            {startAdornment}
+          </div>
+        )}
+        <InputComponent
+          type={type}
+          id={id}
+          {...inputProps}
+          className={cx(withBaseName("input"), inputProps?.className)}
+          disabled={isDisabled}
+          ref={handleRef}
+          value={value}
+          onBlur={handleBlur}
+          onChange={handleChange}
+          onKeyDown={onKeyDown}
+          onKeyUp={onKeyUp}
+          onFocus={handleFocus}
+          onMouseDown={handleMouseDown}
+          onMouseUp={handleMouseUp}
+          onMouseMove={handleMouseMove}
+          readOnly={isReadOnly}
+        />
+        {endAdornment && (
+          <div className={withBaseName("suffixContainer")}>{endAdornment}</div>
+        )}
+        {/* TODO: Confirm implementation of suffix */}
+        {renderSuffix?.({ disabled, focused })}
+      </div>
+      <FormActivationIndicator
+        validationStatus={validationStatus || formFieldValidationStatus}
+        hasIcon={hasStatusIndicator}
       />
-      {endAdornment && (
-        <div className={withBaseName("suffixContainer")}>{endAdornment}</div>
-      )}
-      {/* TODO: Confirm implementation of suffix */}
-      {renderSuffix?.({ disabled, focused })}
     </div>
   );
 });

--- a/packages/core/stories/form-field.doc.stories.mdx
+++ b/packages/core/stories/form-field.doc.stories.mdx
@@ -18,17 +18,41 @@ import { ComponentAnatomy } from "docs/components/ComponentAnatomy";
 
 # Form Field
 
-# API
+Form Field is a wrapper that provides an editable component with various states, a descriptive label, help text and optional or required flags. It’s ADA compliant, and is typically used in the context of a form.
+
+<Canvas>
+  <FormField helperText="Sample helper text" label="Default Form Field label">
+    <Input defaultValue="Value" />
+  </FormField>
+</Canvas>
+
+## How you can use Form Field
+
+Use Form Field when you need to display editable components in a form layout—such as a simple form, filter panel or cash ticket. It’s been optimized to work with the following components:
+
+- [Checkbox Group](/TODO:)
+- [Combo Box](/TODO:)
+- [Dropdown](/TODO:)
+- [Formatted Input](/TODO:)
+- [Input](/TODO:)
+- [Radio Button Group](/TODO:)
+- [Rating](/TODO:)
+- [Switch](/TODO:)
+- [Tokenized Input](/TODO:)
+
+We highly recommend using the Form Field component to provide your form elements with the descriptive label and validation feedback required to ensure ADA compliance.
+
+## Configuring Form Field
 
 ```
 import { FormField } from "@jpmorganchase/uitk-core";
 ```
 
-## Props
+### Props
 
 <ArgsTable of={FormField} />
 
-## HTML Anatomy of a Form Field
+### HTML Anatomy of a Form Field
 
 <Canvas>
   <ComponentAnatomy showControls={false}>
@@ -38,14 +62,14 @@ import { FormField } from "@jpmorganchase/uitk-core";
   </ComponentAnatomy>
 </Canvas>
 
-## CSS Class
+### CSS Class
 
 <CSSClassTable of={FormField} />
 
-## Characteristics Used
+### Characteristics Used
 
 <CharacteristicUsage of={FormField} />
 
-## --uitkFormField CSS Custom Property API
+### --uitkFormField CSS Custom Property API
 
 <CSSVariableTable of={FormField} />

--- a/packages/core/stories/form-field.qa.stories.tsx
+++ b/packages/core/stories/form-field.qa.stories.tsx
@@ -1,6 +1,16 @@
 import cx from "classnames";
-import { FormField, Input } from "@jpmorganchase/uitk-core";
-import { ComponentMeta, Story } from "@storybook/react";
+import {
+  FormField,
+  Input,
+  Checkbox,
+  CheckboxGroup,
+  RadioButton,
+  RadioButtonGroup,
+  StackLayout,
+  Switch,
+  FlexLayout,
+} from "@jpmorganchase/uitk-core";
+import { ComponentMeta, ComponentStory, Story } from "@storybook/react";
 import { QAContainer, QAContainerProps } from "docs/components";
 
 export default {
@@ -104,5 +114,90 @@ export const CompareWithOriginalToolkit: Story = () => {
       className="backwardsCompat"
       imgSrc="/visual-regression-screenshots/FormField-vr-snapshot.png"
     />
+  );
+};
+
+export const WrappingInputs: ComponentStory<typeof FormField> = (props) => {
+  return (
+    <FlexLayout gap={4}>
+      <StackLayout gap={4}>
+        <FormField label="Form Field with Input" {...props}>
+          <Input defaultValue="Value" />
+        </FormField>
+
+        <FormField label="Form Field with CheckboxGroup" {...props}>
+          <CheckboxGroup legend="Uncontrolled CheckboxGroup">
+            <Checkbox defaultChecked label="option 1" value="option-1" />
+            <Checkbox defaultChecked label="option 2" value="option-2" />
+            <Checkbox label="option 3" value="option-3" />
+          </CheckboxGroup>
+        </FormField>
+
+        <FormField label="Form Field with RadioButtonGroup" {...props}>
+          <RadioButtonGroup legend="Uncontrolled RadioButtonGroup">
+            <RadioButton label="option 1" value="option-1" />
+            <RadioButton label="option 2" value="option-2" />
+            <RadioButton label="option 3" value="option-3" />
+          </RadioButtonGroup>
+        </FormField>
+
+        <FormField label="Form Field with Switch" {...props}>
+          <Switch label="Uncontrolled Switch" defaultValue="Value" />
+        </FormField>
+
+        <FormField label="Form Field with Labelless Switch" {...props}>
+          <Switch defaultValue="Value" />
+        </FormField>
+      </StackLayout>
+      <StackLayout gap={4}>
+        <FormField
+          helperText="Some help text"
+          label="Form Field with Input"
+          {...props}
+        >
+          <Input defaultValue="Value" />
+        </FormField>
+
+        <FormField
+          helperText="Some help text"
+          label="Form Field with CheckboxGroup"
+          {...props}
+        >
+          <CheckboxGroup legend="Uncontrolled CheckboxGroup">
+            <Checkbox defaultChecked label="option 1" value="option-1" />
+            <Checkbox defaultChecked label="option 2" value="option-2" />
+            <Checkbox label="option 3" value="option-3" />
+          </CheckboxGroup>
+        </FormField>
+
+        <FormField
+          helperText="Some help text"
+          label="Form Field with RadioButtonGroup"
+          {...props}
+        >
+          <RadioButtonGroup legend="Uncontrolled RadioButtonGroup">
+            <RadioButton label="option 1" value="option-1" />
+            <RadioButton label="option 2" value="option-2" />
+            <RadioButton label="option 3" value="option-3" />
+          </RadioButtonGroup>
+        </FormField>
+
+        <FormField
+          helperText="Some help text"
+          label="Form Field with Switch"
+          {...props}
+        >
+          <Switch label="Uncontrolled Switch" defaultValue="Value" />
+        </FormField>
+
+        <FormField
+          helperText="Some help text"
+          label="Form Field with Labelless Switch"
+          {...props}
+        >
+          <Switch defaultValue="Value" />
+        </FormField>
+      </StackLayout>
+    </FlexLayout>
   );
 };

--- a/packages/core/stories/form-field.qa.stories.tsx
+++ b/packages/core/stories/form-field.qa.stories.tsx
@@ -65,7 +65,7 @@ export const AllExamplesGrid: Story<QAContainerProps> = (props) => {
         label="Warning Form Field"
         validationStatus="warning"
       >
-        <Input />
+        <Input hasStatusIndicator />
       </FormField>
       <FormField
         className={cx(className)}
@@ -90,7 +90,7 @@ export const AllExamplesGrid: Story<QAContainerProps> = (props) => {
         label="Warning Form Field"
         validationStatus="error"
       >
-        <Input />
+        <Input hasStatusIndicator />
       </FormField>
     </QAContainer>
   );

--- a/packages/core/stories/form-field.qa.stories.tsx
+++ b/packages/core/stories/form-field.qa.stories.tsx
@@ -198,6 +198,60 @@ export const WrappingInputs: ComponentStory<typeof FormField> = (props) => {
           <Switch defaultValue="Value" />
         </FormField>
       </StackLayout>
+      <StackLayout gap={4}>
+        <FormField
+          helperText="Some help text"
+          labelPlacement="left"
+          label="Form Field with Input"
+          {...props}
+        >
+          <Input defaultValue="Value" />
+        </FormField>
+
+        <FormField
+          helperText="Some help text"
+          labelPlacement="left"
+          label="Form Field with CheckboxGroup"
+          {...props}
+        >
+          <CheckboxGroup legend="Uncontrolled CheckboxGroup">
+            <Checkbox defaultChecked label="option 1" value="option-1" />
+            <Checkbox defaultChecked label="option 2" value="option-2" />
+            <Checkbox label="option 3" value="option-3" />
+          </CheckboxGroup>
+        </FormField>
+
+        <FormField
+          helperText="Some help text"
+          labelPlacement="left"
+          label="Form Field with RadioButtonGroup"
+          {...props}
+        >
+          <RadioButtonGroup legend="Uncontrolled RadioButtonGroup">
+            <RadioButton label="option 1" value="option-1" />
+            <RadioButton label="option 2" value="option-2" />
+            <RadioButton label="option 3" value="option-3" />
+          </RadioButtonGroup>
+        </FormField>
+
+        <FormField
+          helperText="Some help text"
+          labelPlacement="left"
+          label="Form Field with Switch"
+          {...props}
+        >
+          <Switch label="Uncontrolled Switch" defaultValue="Value" />
+        </FormField>
+
+        <FormField
+          helperText="Some help text"
+          labelPlacement="left"
+          label="Form Field with Labelless Switch"
+          {...props}
+        >
+          <Switch defaultValue="Value" />
+        </FormField>
+      </StackLayout>
     </FlexLayout>
   );
 };

--- a/packages/core/stories/form-field.stories.tsx
+++ b/packages/core/stories/form-field.stories.tsx
@@ -75,8 +75,8 @@ export const HighEmphasis: ComponentStory<typeof FormField> = () => (
         <FormField
           label="High emphasis form field"
           helperText="Helper text value"
-          className="uitkEmphasisHigh"
           labelPlacement="left"
+          className="uitkEmphasisHigh"
         >
           <Input defaultValue="Value" />
         </FormField>

--- a/packages/core/stories/form-field.stories.tsx
+++ b/packages/core/stories/form-field.stories.tsx
@@ -2,6 +2,7 @@ import {
   FormField,
   FormFieldProps,
   Input,
+  StackLayout,
   ToolkitProvider,
 } from "@jpmorganchase/uitk-core";
 import { Dropdown } from "@jpmorganchase/uitk-lab";
@@ -46,36 +47,41 @@ export const LowEmphasis: ComponentStory<typeof FormField> = () => (
 );
 
 export const HighEmphasis: ComponentStory<typeof FormField> = () => (
-  <div
-    style={{
-      display: "grid",
-      rowGap: "20px",
-      columnGap: "20px",
-      gridTemplateColumns: "auto auto",
-      padding: "20px 20px",
-    }}
-  >
-    <div style={{ width: "200px" }}>
-      <h3>High emphasis</h3>
-      <FormField
-        label="High emphasis form field"
-        helperText="Helper text value"
-        className="uitkEmphasisHigh"
-      >
-        <Input defaultValue="Value" />
-      </FormField>
-    </div>
-    <div style={{ width: "200px" }}>
-      <h3>High emphasis with disabled outer ring</h3>
-      <FormField
-        label="Low emphasis form field"
-        helperText="Helper text value"
-        disableFocusRing
-        className="uitkEmphasisHigh"
-      >
-        <Input defaultValue="Value" />
-      </FormField>
-    </div>
+  <div style={{ width: "300px" }}>
+    <StackLayout gap={2}>
+      <div>
+        <h3>High emphasis</h3>
+        <FormField
+          label="High emphasis form field"
+          helperText="Helper text value"
+          className="uitkEmphasisHigh"
+        >
+          <Input defaultValue="Value" />
+        </FormField>
+      </div>
+      <div>
+        <h3>Disabled outer ring</h3>
+        <FormField
+          label="High emphasis form field"
+          helperText="Helper text value"
+          disableFocusRing
+          className="uitkEmphasisHigh"
+        >
+          <Input defaultValue="Value" />
+        </FormField>
+      </div>
+      <div>
+        <h3>Left aligned label</h3>
+        <FormField
+          label="High emphasis form field"
+          helperText="Helper text value"
+          className="uitkEmphasisHigh"
+          labelPlacement="left"
+        >
+          <Input defaultValue="Value" />
+        </FormField>
+      </div>
+    </StackLayout>
   </div>
 );
 
@@ -101,9 +107,28 @@ export const Readonly: ComponentStory<typeof FormField> = () => (
 
 export const HelperText: ComponentStory<typeof FormField> = () => (
   <div style={{ width: "300px" }}>
-    <FormField label="Helper Text Form Field" helperText="Helper text value">
-      <Input defaultValue="Value" />
-    </FormField>
+    <StackLayout gap={2}>
+      <div>
+        <h3>Default helper text</h3>
+        <FormField
+          label="Helper Text Form Field"
+          helperText="Helper text value"
+        >
+          <Input defaultValue="Value" />
+        </FormField>
+      </div>
+
+      <div>
+        <h3>Helper text in tooltip</h3>
+        <FormField
+          label="Helper Text Form Field"
+          helperText="Helper text value"
+          helperTextPlacement="tooltip"
+        >
+          <Input defaultValue="Value" />
+        </FormField>
+      </div>
+    </StackLayout>
   </div>
 );
 


### PR DESCRIPTION
### Overview
This draft is just focusing on detecting "fully supported" children. Not sure how to call this mode but right now it is just focusing on making it all look not broken. The padding needed to be adjusted on label and helper text because otherwise it looks whack. Switch looks bad either way.

### Changes when a child input is not fully supported
- remove status indicator 
- adjust padding on FormLabel and FormHelperText

### New FormField QA story

The following can be seen under the Core > Form Field > QA > Wrapping Inputs

### Before adjusted padding and bottom border

<img src="https://i.imgur.com/NCcmYnD.png" alt="before" />

### After adjusted padding and bottom border

<img src="https://i.imgur.com/KNvG2ej.png" alt="after" />

#### Left aligned label

Not sure what to do about left aligned labels :/

<img src="https://i.imgur.com/JbZglBk.png" alt="Left aligned label" />

