### PR TITLE
Fix onMouseDown prop on Tabstrip being ignored and Improve TypeScript types for Tabs

### DIFF
--- a/.changeset/thin-taxis-sip.md
+++ b/.changeset/thin-taxis-sip.md
@@ -2,4 +2,5 @@
 "@jpmorganchase/uitk-lab": minor
 ---
 
-Allow onMouseDown in Tabstrip to be handled by client code. Tidy typescript types for Tabs
+Fix onMouseDown prop on Tabstrip being ignored.
+Improve TypeScript types for Tabs

--- a/.changeset/thin-taxis-sip.md
+++ b/.changeset/thin-taxis-sip.md
@@ -1,0 +1,5 @@
+---
+"@jpmorganchase/uitk-lab": minor
+---
+
+Allow onMouseDown in Tabstrip to be handled by client code. Tidy typescript types for Tabs

--- a/packages/lab/src/tabs/Tab.tsx
+++ b/packages/lab/src/tabs/Tab.tsx
@@ -132,7 +132,7 @@ export const Tab = forwardRef(function Tab(
   };
 
   const handleMouseDown = (e: MouseEvent<HTMLElement>): void => {
-    onMouseDown && onMouseDown(e, index);
+    onMouseDown?.(e);
   };
 
   const getLabel = () => {

--- a/packages/lab/src/tabs/TabsTypes.ts
+++ b/packages/lab/src/tabs/TabsTypes.ts
@@ -100,7 +100,7 @@ export interface responsiveDataAttributes {
 
 export type TabProps = Omit<
   HTMLAttributes<HTMLElement>,
-  "onClick" | "onKeyUp" | "onMouseDown" /*| "children" */
+  "onClick" | "onKeyUp"
 > & {
   ariaControls?: AriaAttributes["aria-controls"];
   closeable?: boolean;
@@ -120,20 +120,8 @@ export type TabProps = Omit<
   onEnterEditMode?: () => void;
   onExitEditMode?: exitEditHandler;
   onKeyUp?: (e: KeyboardEvent, index: number) => void;
-  onMouseDown?: (e: MouseEvent<HTMLElement>, index: number) => void;
   orientation?: "horizontal" | "vertical";
   tabChildIndex?: number;
 };
 
 export type TabElement = ReactElement<TabProps>;
-
-// type TabWithLabel = BaseTabProps & {
-//   label: EditableLabelProps["defaultValue"];
-//   children?: ReactNode;
-// };
-// type TabWithChildren = BaseTabProps & {
-//   children: ReactNode;
-//   label?: EditableLabelProps["defaultValue"];
-// };
-
-// export type TabProps = TabWithChildren | TabWithLabel;

--- a/packages/lab/src/tabs/Tabstrip.tsx
+++ b/packages/lab/src/tabs/Tabstrip.tsx
@@ -12,6 +12,7 @@ import React, {
   ForwardedRef,
   forwardRef,
   KeyboardEvent,
+  MouseEvent,
   RefObject,
   useCallback,
   useImperativeHandle,
@@ -77,6 +78,7 @@ export const Tabstrip = forwardRef(function Tabstrip(
     onCloseTab,
     onEnterEditMode,
     onExitEditMode,
+    onMouseDown,
     onMoveTab,
     orientation = "horizontal",
     overflowMenu: overflowMenuProp = true,
@@ -184,7 +186,13 @@ export const Tabstrip = forwardRef(function Tabstrip(
 
   const { getTriggerProps, getTooltipProps } = useTooltip({});
 
-  const { activeTabIndex, activateTab, addTab, ...tabstripHook } = useTabstrip({
+  const {
+    activeTabIndex,
+    activateTab,
+    addTab,
+    onMouseDown: tabstripHookMouseDown,
+    ...tabstripHook
+  } = useTabstrip({
     activeTabIndex: activeTabIndexProp,
     allowDragDrop,
     collectionHook,
@@ -252,9 +260,23 @@ export const Tabstrip = forwardRef(function Tabstrip(
     [tabstripHook.navigationProps]
   );
 
-  const handleOverflowMenuOpen = useCallback((open) => {
-    setShowOverflowMenu(open);
-  }, []);
+  const handleOverflowMenuOpen = useCallback(
+    (open) => {
+      setShowOverflowMenu(open);
+    },
+    [setShowOverflowMenu]
+  );
+
+  const handleMouseDown = useCallback(
+    (evt: MouseEvent<HTMLDivElement>) => {
+      console.log("handleMouseDown ", {
+        evt,
+      });
+      onMouseDown?.(evt);
+      tabstripHookMouseDown?.(evt);
+    },
+    [onMouseDown, tabstripHookMouseDown]
+  );
 
   // shouldn't we use ref for this ?
   useIsomorphicLayoutEffect(() => {
@@ -320,7 +342,7 @@ export const Tabstrip = forwardRef(function Tabstrip(
           ...tabstripHook.navigationProps,
           id: item.id,
           key: index,
-          onMouseDown: tabstripHook.onMouseDown,
+          onMouseDown: handleMouseDown,
           tabIndex,
         };
 

--- a/packages/lab/src/tabs/Tabstrip.tsx
+++ b/packages/lab/src/tabs/Tabstrip.tsx
@@ -269,9 +269,6 @@ export const Tabstrip = forwardRef(function Tabstrip(
 
   const handleMouseDown = useCallback(
     (evt: MouseEvent<HTMLDivElement>) => {
-      console.log("handleMouseDown ", {
-        evt,
-      });
       onMouseDown?.(evt);
       tabstripHookMouseDown?.(evt);
     },

--- a/packages/lab/src/tabs/drag-drop/useDragDropNaturalMovement.tsx
+++ b/packages/lab/src/tabs/drag-drop/useDragDropNaturalMovement.tsx
@@ -243,7 +243,7 @@ export const useDragDropNaturalMovement: DragDropHook = ({
 
   const mouseDownHandler: MouseEventHandler = useCallback(
     (evt) => {
-      if (containerRef.current) {
+      if (containerRef.current && !evt.defaultPrevented) {
         const { POS } = dimensions(orientation);
         const { [POS]: clientPos } = evt;
         startPos.current = clientPos;

--- a/packages/lab/src/tabs/useEditableItem.ts
+++ b/packages/lab/src/tabs/useEditableItem.ts
@@ -18,12 +18,12 @@ export interface Editable {
   onExitEditMode: ExitEditModeHandler;
   setEditing: (value: boolean) => void;
 }
-interface EditableItemHookProps extends Partial<Editable> {
+export interface EditableItemHookProps extends Partial<Editable> {
   highlightedIdx: number;
   indexPositions: OverflowItem[];
 }
 
-interface EditableItemHookResult extends Editable {
+export interface EditableItemHookResult extends Editable {
   onKeyDown: (evt: KeyboardEvent) => void;
 }
 
@@ -77,7 +77,6 @@ export const useEditableItem = ({
   return {
     editing,
     onKeyDown,
-    // careful what do we use these for ?
     onEnterEditMode,
     onExitEditMode,
     setEditing,

--- a/packages/lab/src/tabs/useKeyboardNavigation.ts
+++ b/packages/lab/src/tabs/useKeyboardNavigation.ts
@@ -80,7 +80,6 @@ export interface ContainerNavigationProps {
   onFocus: FocusEventHandler;
   onMouseDownCapture: MouseEventHandler;
   onMouseLeave: MouseEventHandler;
-  onMouseMove: MouseEventHandler;
 }
 
 interface TabstripNavigationHookProps {
@@ -301,17 +300,8 @@ export const useKeyboardNavigation = ({
         setHasFocus(false);
       }
     },
-    // onClick: handleContainerClick,
-    onMouseDown: handleContainerMouseDown,
+    onMouseDownCapture: handleContainerMouseDown,
     onFocus: handleFocus,
-    // onKeyDown: () => console.log("[useKeyboardNavigation] onKeyDown"),
-    onMouseDownCapture: () => {
-      // console.log("[useKeyboardNavigation onMouseDownCapture")
-    },
-
-    onMouseMove: () => {
-      // console.log("[useKeyboardNavigation onMouseMove");
-    },
     onMouseLeave: () => {
       keyboardNavigation.current = true;
       setHighlightedIdx(-1);

--- a/packages/lab/src/tabs/useTabstrip.ts
+++ b/packages/lab/src/tabs/useTabstrip.ts
@@ -2,7 +2,6 @@ import {
   createElement,
   KeyboardEvent,
   MouseEvent,
-  MouseEventHandler,
   RefObject,
   useEffect,
   useCallback,
@@ -15,7 +14,11 @@ import {
 } from "./useKeyboardNavigation";
 import { dragStrategy, useDragDrop, DragHookResult } from "./drag-drop";
 import { useSelection } from "./useSelection";
-import { ExitEditModeHandler, useEditableItem } from "./useEditableItem";
+import {
+  ExitEditModeHandler,
+  useEditableItem,
+  EditableItemHookResult,
+} from "./useEditableItem";
 import { OverflowCollectionHookResult } from "../responsive";
 
 import {
@@ -47,22 +50,20 @@ interface tabstripHookProps {
   tabs?: TabDescriptor[] | TabElement[];
 }
 
-interface tabstripHookResult {
+interface tabstripHookResult
+  extends DragHookResult,
+    Pick<EditableItemHookResult, "editing"> {
   activateTab: (tabIndex: number) => void;
   activeTabIndex: number;
   addTab: (indexPosition?: number) => void;
   closeTab: (indexPosition: number) => void;
   containerProps: ContainerNavigationProps;
   controlledSelection: boolean;
-  editing?: boolean;
   highlightedIdx: number;
   focusVisible: number;
   focusIsWithinComponent: boolean;
   focusTab: (tabIndex: number, immediateFocus?: boolean) => void;
-  isDragging?: boolean;
   navigationProps: navigationProps;
-  onMouseDown?: MouseEventHandler;
-  revealOverflowedItems: boolean;
   tabProps: composableTabProps;
 }
 
@@ -190,9 +191,6 @@ export const useTabstrip = ({
     [keyboardHook, selectionHook, editableHook]
   );
 
-  // const { tabProps: dragTabProps, ...dragProps } = dragDropHook;
-  const dragProps = dragDropHook;
-
   const navigationProps = {
     onFocus: keyboardHook.onFocus,
     onKeyDown: handleKeyDown,
@@ -202,7 +200,6 @@ export const useTabstrip = ({
     onClick: handleClick,
     onEnterEditMode: editableHook.onEnterEditMode,
     onExitEditMode: handleExitEditMode,
-    // ...dragTabProps,
   };
 
   const addTab = useCallback(
@@ -295,6 +292,7 @@ export const useTabstrip = ({
     closeTab,
     containerProps: keyboardHook.containerProps,
     controlledSelection: selectionHook.isControlled,
+    editing: editableHook.editing,
     focusTab: keyboardHook.focusTab,
     focusIsWithinComponent: keyboardHook.focusIsWithinComponent,
     focusVisible: keyboardHook.focusVisible,
@@ -302,7 +300,6 @@ export const useTabstrip = ({
     activeTabIndex: selectionHook.selected,
     navigationProps,
     tabProps,
-    ...dragProps,
-    ...editableHook,
+    ...dragDropHook,
   };
 };


### PR DESCRIPTION
Allowing client code to supply onMouseDown to Tabstrip allows for client controlled drag drop.
Tidy up some of the types in Tabs.
Remove unused code.