### PR TITLE
List fix, do not throw exception if focussed when empty

### DIFF
--- a/.changeset/sour-icons-relax.md
+++ b/.changeset/sour-icons-relax.md
@@ -1,0 +1,5 @@
+---
+"@jpmorganchase/uitk-lab": minor
+---
+
+Bug: List should not throw a runtime exception if focused when empty

--- a/packages/lab/src/__tests__/__e2e__/list/List.keyboardNavigation.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/list/List.keyboardNavigation.cy.tsx
@@ -38,11 +38,26 @@ const ITEMS_PER_PAGE = 2;
       });
 
       describe("when focused", () => {
-        it("should highlight the first item with a focus ring", () => {
-          cy.findByRole("listbox").focus();
-          cy.get(`#list-item-0`)
-            .should("be.highlighted")
-            .should("have.focusVisible");
+        describe("with ListItems", () => {
+          it("should highlight the first item with a focus ring", () => {
+            cy.findByRole("listbox").focus();
+            cy.get(`#list-item-0`)
+              .should("be.highlighted")
+              .should("have.focusVisible");
+          });
+        });
+        describe("with no ListItems", () => {
+          it("should highlight List itself with a focus ring", () => {
+            cy.mount(
+              isDeclarative ? (
+                <List />
+              ) : (
+                <List<ItemWithLabel, "deselectable"> source={[]} />
+              )
+            );
+            cy.findByRole("listbox").focus();
+            cy.findByRole("listbox").should("have.focusVisible");
+          });
         });
       });
 

--- a/packages/lab/src/list/List.css
+++ b/packages/lab/src/list/List.css
@@ -78,3 +78,6 @@
   right: 0;
   will-change: transform;
 }
+.uitkList.uitkFocusVisible:after {
+  inset: 2px;
+}

--- a/packages/lab/src/list/List.tsx
+++ b/packages/lab/src/list/List.tsx
@@ -13,6 +13,7 @@ import {
   CollectionItem,
   isSelected,
   itemToString as defaultItemToString,
+  LIST_FOCUS_VISIBLE,
   ScrollingAPI,
   SelectionStrategy,
   useCollectionItems,
@@ -323,6 +324,7 @@ export const List = forwardRef(function List<
         [withBaseName("borderless")]: borderless,
         uitkDisabled: listDisabled,
         [withBaseName("collapsible")]: collapsibleHeaders,
+        uitkFocusVisible: highlightedIndex === LIST_FOCUS_VISIBLE,
       })}
       id={`${id}`}
       ref={useForkRef<HTMLDivElement>(rootRef, forwardedRef)}

--- a/packages/lab/stories/list.stories.tsx
+++ b/packages/lab/stories/list.stories.tsx
@@ -779,6 +779,53 @@ export const WithTextHighlightDeclarative: Story<ListProps> = () => {
   );
 };
 
+export const EmptyList: Story<ListProps> = (props) => {
+  const buttonsRef = useRef<HTMLDivElement>(null);
+  const NO_DATA = useMemo<string[]>(() => [], []);
+  const [data, setData] = useState<string[]>(NO_DATA);
+
+  const resetData = () => {
+    if (data === NO_DATA) {
+      setData(usa_states);
+    } else {
+      setData(NO_DATA);
+    }
+  };
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        width: "100%",
+        height: "100%",
+        maxWidth: 292,
+      }}
+    >
+      <div>
+        When List has no data, focusVisible is applied to the List itself. When
+        data is present, ListItems receive focusVisible.
+      </div>
+      <div
+        ref={buttonsRef}
+        style={{ display: "flex", justifyContent: "flex-end", zIndex: 1 }}
+      >
+        <Button onClick={resetData}>
+          {data === NO_DATA ? "Load Data" : "Clear Data"}
+        </Button>
+      </div>
+      <div>
+        <List
+          aria-label="Controlled List example"
+          height={400}
+          source={data}
+          {...props}
+        />
+      </div>
+    </div>
+  );
+};
+
 // export const SimpleListDefaultHighlight = () => {
 //   return (
 //     <div


### PR DESCRIPTION
ListItems may be populated dynamically - must support the scenario where there may be no data. An empty list currently throws an exception when focus is received.

When empty list receives focus, apply focusVisible to the List.  