### PR TITLE
Make Button's default type "button" instead of submit

### DIFF
--- a/.changeset/swift-cows-brake.md
+++ b/.changeset/swift-cows-brake.md
@@ -1,0 +1,5 @@
+---
+"@jpmorganchase/uitk-core": minor
+---
+
+Set button's default type attribute to "button" rather than "submit"

--- a/packages/core/src/__tests__/__e2e__/button/Button.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/button/Button.cy.tsx
@@ -50,4 +50,14 @@ describe("Given a Button", () => {
     cy.findByRole("button").realClick();
     cy.get("@clickSpy").should("not.be.called");
   });
+
+  it("should apply type prop to button element", () => {
+    cy.mount(<FeatureButton type="submit" />);
+    cy.findByRole("button").should("have.attr", "type", "submit");
+  });
+
+  it("should apply default type prop to button element", () => {
+    cy.mount(<FeatureButton />);
+    cy.findByRole("button").should("have.attr", "type", "button");
+  });
 });

--- a/packages/core/src/button/Button.tsx
+++ b/packages/core/src/button/Button.tsx
@@ -38,7 +38,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       onBlur,
       onClick,
       role: roleProp,
-      type: typeProp,
+      type = "button",
       variant = "primary",
       ...restProps
     },
@@ -65,7 +65,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         role={roleProp}
         {...restProps}
         ref={ref}
-        type={typeProp || "button"}
+        type={type}
       >
         <span className={withBaseName("label")}>{children}</span>
       </button>

--- a/packages/core/src/button/Button.tsx
+++ b/packages/core/src/button/Button.tsx
@@ -38,6 +38,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       onBlur,
       onClick,
       role: roleProp,
+      type: typeProp,
       variant = "primary",
       ...restProps
     },
@@ -64,6 +65,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         role={roleProp}
         {...restProps}
         ref={ref}
+        type={typeProp || "button"}
       >
         <span className={withBaseName("label")}>{children}</span>
       </button>


### PR DESCRIPTION
This pull request fixes issue #461, by setting the attribute `type` to "button".