### PR TITLE
ADA tweaks on DeckLayout and DeckItem

### DIFF
--- a/packages/core/src/__tests__/__e2e__/layout/Deck.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/layout/Deck.cy.tsx
@@ -1,10 +1,13 @@
 import { composeStories } from "@storybook/testing-react";
 import * as deckStories from "@stories/layout/deck-layout.stories";
+import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
 
 const composedStories = composeStories(deckStories);
 const { DefaultDeckLayout } = composedStories;
 
 describe("Given a deck layout", () => {
+  checkAccessibility(composedStories);
+
   describe("WHEN no custom values are provided", () => {
     it("THEN it should render with default values", () => {
       cy.mount(<DefaultDeckLayout />);

--- a/packages/core/src/layout/DeckItem/DeckItem.tsx
+++ b/packages/core/src/layout/DeckItem/DeckItem.tsx
@@ -1,6 +1,6 @@
 import cx from "classnames";
 import { forwardRef, HTMLAttributes, useMemo, useRef } from "react";
-import { makePrefixer, useForkRef } from "../../utils";
+import { makePrefixer, useForkRef, useIdMemo } from "../../utils";
 import { LayoutAnimation } from "../types";
 import "./DeckItem.css";
 
@@ -22,19 +22,18 @@ export const DeckItem = forwardRef<HTMLDivElement, DeckItemProps>(
       className,
       index,
       role = "group",
+      id,
       ...rest
     },
     ref
   ) {
     const sliderRef = useRef<HTMLDivElement | null>(null);
 
+    const isCurrent = activeIndex === index;
+
     const position = useMemo(() => {
-      return activeIndex === index
-        ? "current"
-        : activeIndex < index
-        ? "next"
-        : "previous";
-    }, [activeIndex, index]);
+      return isCurrent ? "current" : activeIndex < index ? "next" : "previous";
+    }, [activeIndex, index, isCurrent]);
 
     const classesIndex = animation && position === "current" ? 0 : 1;
 
@@ -43,7 +42,8 @@ export const DeckItem = forwardRef<HTMLDivElement, DeckItemProps>(
       `${animation || "fade"}-out`, // out-left
     ];
 
-    // TODO: add aria attributes (labelledby, roledescription, hidden)
+    const deckItemId = useIdMemo(id);
+
     return (
       <div
         className={cx(
@@ -57,6 +57,8 @@ export const DeckItem = forwardRef<HTMLDivElement, DeckItemProps>(
         )}
         ref={useForkRef(ref, sliderRef)}
         role={role}
+        tabIndex={isCurrent ? 0 : -1}
+        id={deckItemId}
         {...rest}
       >
         {children}

--- a/packages/core/src/layout/DeckLayout/DeckLayout.tsx
+++ b/packages/core/src/layout/DeckLayout/DeckLayout.tsx
@@ -8,7 +8,7 @@ import {
 } from "react";
 import { makePrefixer, useIsomorphicLayoutEffect } from "../../utils";
 import { LayoutAnimation, LayoutAnimationDirection } from "../types";
-import { DeckItem } from "../DeckItem";
+import { DeckItem, DeckItemProps } from "../DeckItem";
 import { useWidth } from "../../responsive";
 import "./DeckLayout.css";
 
@@ -27,6 +27,10 @@ export interface DeckLayoutProps extends HTMLAttributes<HTMLDivElement> {
    * The direction in which items will transition.
    **/
   direction?: LayoutAnimationDirection;
+  /**
+   * Props to be passed to the DeckItem component.
+   */
+  deckItemProps?: Partial<DeckItemProps>;
 }
 
 const withBaseName = makePrefixer("uitkDeckLayout");
@@ -40,6 +44,7 @@ export const DeckLayout = forwardRef<HTMLDivElement, DeckLayoutProps>(
       children,
       direction = "horizontal",
       style,
+      deckItemProps,
       ...rest
     },
     ref
@@ -109,6 +114,7 @@ export const DeckLayout = forwardRef<HTMLDivElement, DeckLayoutProps>(
                 index={index}
                 activeIndex={activeIndex}
                 animation={animation}
+                {...deckItemProps}
               >
                 {child}
               </DeckItem>

--- a/packages/core/stories/layout/deck-layout.stories.tsx
+++ b/packages/core/stories/layout/deck-layout.stories.tsx
@@ -18,7 +18,7 @@ export default {
 const deckCards = (slides: number) =>
   Array.from({ length: slides }, (_, index) => (
     <Card key={index}>
-      <h2>{`Deck Item ${index + 1}`}</h2>
+      <h2 id="deck_item_title">{`Deck Item ${index + 1}`}</h2>
       <p>
         We can implement your cross-border liquidity model in just a few months,
         depending on the options, scope and complexity.
@@ -48,7 +48,14 @@ const DefaultDeckLayoutStory: ComponentStory<typeof DeckLayout> = (args) => {
     <>
       <button onClick={handleDecrease}>Previous</button>
       <button onClick={handleIncrease}>Next</button>
-      <DeckLayout {...args} activeIndex={currentIndex}>
+      <DeckLayout
+        {...args}
+        activeIndex={currentIndex}
+        deckItemProps={{
+          "aria-roledescription": "slide",
+          "aria-labelledby": "deck_item_title",
+        }}
+      >
         {deckCards(slides)}
       </DeckLayout>
     </>
@@ -75,7 +82,11 @@ const WithTabStrip: ComponentStory<typeof DeckLayout> = (args) => {
           <Tab label={label} key={i} />
         ))}
       </Tabstrip>
-      <DeckLayout activeIndex={activeTabIndex} {...args}>
+      <DeckLayout
+        activeIndex={activeTabIndex}
+        deckItemProps={{ role: "tabpanel" }}
+        {...args}
+      >
         {tabs.map((tab, index) => {
           return (
             <Card key={index}>


### PR DESCRIPTION
- Add accessibility checks to `Deck` cypress tests
- Add `tabIndex` and `id` to `DeckItem`
- Add `deckItemProps` prop to `DeckLayout`
- Make ADA tweaks on storybook examples