### PR TITLE
fix overflow detection issue for overflow containers

### DIFF
--- a/.changeset/serious-cars-agree.md
+++ b/.changeset/serious-cars-agree.md
@@ -1,0 +1,5 @@
+---
+"@jpmorganchase/uitk-lab": minor
+---
+
+use of scrollHeight to detect overflow doesn't work correctly. Fix for horizontal overflow containers

--- a/packages/lab/src/responsive/overflowUtils.tsx
+++ b/packages/lab/src/responsive/overflowUtils.tsx
@@ -36,7 +36,11 @@ export const getIsOverflowed = (managedItems: OverflowItem[]) =>
 export const measureContainer = (
   ref: ElementRef,
   orientation: orientationType = "horizontal"
-): { innerContainerSize: number; rootContainerDepth: number } => {
+): {
+  innerContainerSize: number;
+  rootContainerDepth: number;
+  innerContainerDepth?: number;
+} => {
   const innerElement = ref.current as HTMLElement;
   const container = innerElement.parentElement;
   if (container) {
@@ -44,7 +48,11 @@ export const measureContainer = (
       innerElement.getBoundingClientRect();
     const { width, height } = container.getBoundingClientRect();
     if (orientation === "horizontal") {
-      return { innerContainerSize: innerWidth, rootContainerDepth: height };
+      return {
+        innerContainerSize: innerWidth,
+        rootContainerDepth: height,
+        innerContainerDepth: innerHeight,
+      };
     } else {
       return { innerContainerSize: innerHeight, rootContainerDepth: width };
     }
@@ -62,16 +70,18 @@ export const measureContainerOverflow = (
   rootContainerDepth: number;
 } => {
   const innerElement = ref.current as HTMLElement;
-  const { innerContainerSize, rootContainerDepth } = measureContainer(
-    ref,
-    orientation
-  );
+  const {
+    innerContainerSize,
+    rootContainerDepth,
+    innerContainerDepth = 0,
+  } = measureContainer(ref, orientation);
   const scrollDepth =
     orientation === "horizontal"
-      ? innerElement.scrollHeight
+      ? innerContainerDepth
       : innerElement.scrollWidth;
 
   const isOverflowing = rootContainerDepth < scrollDepth;
+
   return { isOverflowing, innerContainerSize, rootContainerDepth };
 };
 

--- a/packages/lab/src/responsive/useOverflow.ts
+++ b/packages/lab/src/responsive/useOverflow.ts
@@ -2,7 +2,6 @@ import { useCallback, useRef } from "react";
 import {
   addAll,
   allExceptOverflowIndicator,
-  getIsOverflowed,
   getOverflowIndicator,
   isOverflowed,
   measureContainerOverflow,
@@ -311,39 +310,6 @@ export const useOverflow = ({
       updateOverflow,
     ]
   );
-  // const handleResize = useCallback(
-  //   (size: number, containerHasGrown?: boolean) => {
-  //     const { current: managedItems } = overflowItemsRef;
-  //     const isOverflowing = getIsOverflowed(managedItems);
-  //     innerContainerSizeRef.current = size;
-  //     const renderedSize = managedItems.reduce(allExceptOverflowIndicator, 0);
-  //     const willOverflow = renderedSize > size;
-
-  //     console.log(
-  //       `useOverflow handleResize size ${size} rebnderedSize=${renderedSize} isOverflowing ${isOverflowing} willOverflow ${willOverflow}`
-  //     );
-
-  //     if (!isOverflowing && willOverflow) {
-  //       // entering overflow
-  //       // TODO if client is not using an overflow indicator, there is nothing to do here,
-  //       // just let nature take its course. How do we know this ?
-  //       // This is when we need to add width to measurements we are tracking
-  //       resetMeasurements(true, size);
-  //     } else if (isOverflowing && containerHasGrown) {
-  //       // Note: it must have been previously overflowing, too
-  //       // check to see if we can reinstate one or more items
-  //       removeOverflow(size);
-  //     } else if (isOverflowing && willOverflow) {
-  //       // Note: container must have shrunk
-  //       // still overflowing, possibly more overflowing than before
-  //       const renderedSize = managedItems
-  //         .filter(notOverflowed)
-  //         .reduce(addAll, 0);
-  //       updateOverflow(size, renderedSize);
-  //     }
-  //   },
-  //   [overflowItemsRef, removeOverflow, resetMeasurements, updateOverflow]
-  // );
 
   return {
     onResize: handleResize,


### PR DESCRIPTION
We sometimes see a nasty shimmering effect on Tabstrip or Toolbar at a certain width. It gets stuck in an infinite loop of rendering with and then without the overflow indicator.
The root cause is the method it used to detect overflow, using scrollHeight/width. It's not reliable. 
This is now fixed for horizontal scroll containers. In fact, this fix is to restore the original mechanism used for overflow detection. The reason this was changed was because it did not work in Vertical scrollbars, because of a bug in most browsers on a wrapping flexbox, when flex-direction is column. When such a container wraps, the width is not increased as it a should be.
Vertical Toolbars/Tabstrips will still have the bug, which requires a more complex fix in these cases. Horizontal usage is more common, though, so this fix should help. 

Update: This solution is no longer working. Looks like the height of a Wrapped horizontal flexbox is now incorrect, just as the width of a wrapped vertical flexbox has always been incorrect. What I see when inspecting a wrapped flexbox in devtools also looks different.  This is a notoriously buggy aspect of flexbox, looks like there is no reliable way to determine from a flexbox container, whether is is wrapping or not. One solution which is guaranteed to work is a brute force measurement of each childs position. Wanted to avoid that, but I'll go for that solution.

Final update: now fixed for all scenarios. 