### PR TITLE
Grid keyboard handling refactoring and bugfixes

### DIFF
--- a/packages/grid/src/EditorContext.ts
+++ b/packages/grid/src/EditorContext.ts
@@ -1,6 +1,7 @@
 import { createContext, useContext } from "react";
 
 export interface EditorContext {
+  initialText?: string;
   editMode?: boolean;
   startEditMode: () => void;
   endEditMode: (value: string) => void;

--- a/packages/grid/src/Grid.css
+++ b/packages/grid/src/Grid.css
@@ -143,6 +143,10 @@
   --grid-rowSeparator-color: var(--uitkGrid-rowSeparator-color, var(--grid-rowSeparator-color-default));
   --grid-columnSeparator-color: var(--uitkGrid-columnSeparator-color, var(--grid-columnSeparator-color-default));
   --grid-rowSeparator-color-divided: var(--uitkGrid-rowSeparator-color-divided, var(--grid-rowSeparator-color-divided-default));
+
+  --grid-columnGhost-borderColor: var(--uitkGrid-columnGhost-borderColor, var(--uitk-palette-interact-border-hover));
+  --grid-columnGhost-borderWidth: var(--uitkGrid-columnGhost-borderWidth, 1px);
+  --grid-columnGhost-boxShadow: var(--uitkGrid-columnGhost-boxShadow, var(--uitk-overlayable-shadow-drag));
 }
 
 .uitkGrid {

--- a/packages/grid/src/Grid.tsx
+++ b/packages/grid/src/Grid.tsx
@@ -386,12 +386,6 @@ export const Grid = function Grid<T>(props: GridProps<T>) {
     [leftCols, midCols, rightCols]
   );
 
-  const colIdxByKey = useMemo(
-    () =>
-      new Map<string, number>(cols.map((c, i) => [c.info.props.id, c.index])),
-    [cols]
-  );
-
   const scroll = useCallback(
     (left?: number, top?: number, source?: "user" | "table") => {
       setScrollSource(source || "user");

--- a/packages/grid/src/Grid.tsx
+++ b/packages/grid/src/Grid.tsx
@@ -826,14 +826,22 @@ export const Grid = function Grid<T>(props: GridProps<T>) {
 
   const onKeyDown: KeyboardEventHandler<HTMLDivElement> = useCallback(
     (event) => {
-      [
-        navigationKeyHandler,
-        clipboardKeyHandler,
-        selectionKeyHandler,
-        editModeKeyHandler,
-      ].find((handler) => {
-        return handler(event);
-      });
+      if (cursorColIdx != undefined && cursorRowIdx != undefined) {
+        const column = cols[cursorColIdx];
+        if (column.info.props.onKeyDown) {
+          column.info.props.onKeyDown(event, cursorRowIdx);
+        }
+      }
+      if (!event.isPropagationStopped()) {
+        [
+          navigationKeyHandler,
+          clipboardKeyHandler,
+          selectionKeyHandler,
+          editModeKeyHandler,
+        ].find((handler) => {
+          return handler(event);
+        });
+      }
     },
     [
       navigationKeyHandler,

--- a/packages/grid/src/Grid.tsx
+++ b/packages/grid/src/Grid.tsx
@@ -173,7 +173,7 @@ export const Grid = function Grid<T>(props: GridProps<T>) {
     onRowSelected,
     columnMove,
     onColumnMoved,
-    cellSelectionMode = "range",
+    cellSelectionMode = "none",
     onVisibleRowRangeChange,
   } = props;
 

--- a/packages/grid/src/Grid.tsx
+++ b/packages/grid/src/Grid.tsx
@@ -668,7 +668,11 @@ export const Grid = function Grid<T>(props: GridProps<T>) {
             }
           } else {
             if (cursorRowIdx != undefined) {
-              selectRows(cursorRowIdx, event.shiftKey, event.metaKey);
+              selectRows({
+                rowIndex: cursorRowIdx,
+                shift: event.shiftKey,
+                meta: event.metaKey,
+              });
             }
           }
           break;

--- a/packages/grid/src/Grid.tsx
+++ b/packages/grid/src/Grid.tsx
@@ -1,5 +1,6 @@
 import React, {
   CSSProperties,
+  KeyboardEvent,
   KeyboardEventHandler,
   MouseEventHandler,
   ReactNode,
@@ -206,6 +207,7 @@ export const Grid = function Grid<T>(props: GridProps<T>) {
   );
 
   const [editMode, setEditMode] = useState<boolean>(false);
+  const [initialText, setInitialText] = useState<string | undefined>(undefined);
 
   const resizeClient = useCallback(
     (clW: number, clH: number, sbW: number, sbH: number) => {
@@ -421,6 +423,7 @@ export const Grid = function Grid<T>(props: GridProps<T>) {
     const c = cols[cursorColIdx];
     const isEditable = !!contextValue.getEditor(c.info.props.id);
     if (isEditable) {
+      setInitialText(text);
       setEditMode(true);
     }
   };
@@ -544,12 +547,13 @@ export const Grid = function Grid<T>(props: GridProps<T>) {
 
   const editorContext: EditorContext = useMemo(
     () => ({
+      initialText,
       editMode,
       startEditMode,
       endEditMode,
       cancelEditMode,
     }),
-    [editMode, startEditMode, endEditMode, cancelEditMode]
+    [editMode, startEditMode, endEditMode, cancelEditMode, initialText]
   );
 
   const cursorContext: CursorContext = useMemo(
@@ -619,130 +623,97 @@ export const Grid = function Grid<T>(props: GridProps<T>) {
     [rangeSelection.onKeyboardRangeSelectionEnd]
   );
 
-  const onKeyDown: KeyboardEventHandler<HTMLDivElement> = useCallback(
-    (event) => {
+  const editModeKeyHandler = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
       const { key } = event;
-      // console.log(`onKeyDown. key: ${event.key}`);
-
-      if (key === "Shift") {
-        rangeSelection.onKeyboardRangeSelectionStart({
-          rowIdx: cursorRowIdx || 0,
-          colIdx: cursorColIdx || 0,
-        });
-        return;
-      }
-      if (key === "ArrowLeft") {
-        moveCursor(cursorRowIdx, (cursorColIdx || 0) - 1);
-        return;
-      }
-      if (key === "ArrowRight") {
-        moveCursor(cursorRowIdx, (cursorColIdx || 0) + 1);
-        return;
-      }
-      if (key === "ArrowUp") {
-        moveCursor((cursorRowIdx || 0) - 1, cursorColIdx);
-        return;
-      }
-      if (key === "ArrowDown") {
-        moveCursor((cursorRowIdx || 0) + 1, cursorColIdx);
-        return;
-      }
-      if (key === "PageUp") {
-        moveCursor((cursorRowIdx || 0) - PAGE_SIZE, cursorColIdx);
-        return;
-      }
-      if (key === "PageDown") {
-        moveCursor((cursorRowIdx || 0) + PAGE_SIZE, cursorColIdx);
-        return;
-      }
-      if (key === "Home") {
-        if (!event.ctrlKey) {
-          moveCursor(cursorRowIdx, 0);
-        } else {
-          moveCursor(0, 0);
-        }
-        return;
-      }
-      if (key === "End") {
-        if (!event.ctrlKey) {
-          moveCursor(cursorRowIdx, cols.length - 1);
-        } else {
-          moveCursor(rowData.length - 1, cols.length - 1);
-        }
-        return;
-      }
-      if (key === "F2" || key === "Backspace") {
-        startEditMode();
-        return;
-      }
-      if (key === "Tab") {
-        if (!event.ctrlKey && !event.metaKey && !event.altKey) {
-          if (cursorColIdx == undefined || cursorRowIdx == undefined) {
-            moveCursor(0, 0);
+      switch (key) {
+        case "F2":
+        case "Backspace":
+          startEditMode();
+          break;
+        case "Escape":
+          cancelEditMode();
+          break;
+        default:
+          if (
+            !editMode &&
+            !event.ctrlKey &&
+            !event.metaKey &&
+            !event.altKey &&
+            /^[\w\d ]$/.test(key)
+          ) {
+            startEditMode(key);
           } else {
-            if (!event.shiftKey) {
-              if (cursorColIdx < cols.length - 1) {
-                moveCursor(cursorRowIdx, cursorColIdx + 1);
-              } else {
-                if (cursorRowIdx < rowData.length - 1) {
-                  moveCursor(cursorRowIdx + 1, 0);
-                }
-              }
-            } else {
-              if (cursorColIdx > 0) {
-                moveCursor(cursorRowIdx, cursorColIdx - 1);
-              } else {
-                if (cursorRowIdx > 0) {
-                  moveCursor(cursorRowIdx - 1, cols.length - 1);
-                }
-              }
+            return false;
+          }
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      return true;
+    },
+    [startEditMode, editMode, cancelEditMode]
+  );
+
+  const selectionKeyHandler = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      const { key } = event;
+      switch (key) {
+        case "Shift":
+          rangeSelection.onKeyboardRangeSelectionStart({
+            rowIdx: cursorRowIdx || 0,
+            colIdx: cursorColIdx || 0,
+          });
+          break;
+        case " ":
+          if (event.ctrlKey) {
+            if (cursorColIdx != undefined) {
+              rangeSelection.selectRange({
+                start: { rowIdx: 0, colIdx: cursorColIdx },
+                end: { rowIdx: rowData.length, colIdx: cursorColIdx },
+              });
+            }
+          } else {
+            if (cursorRowIdx != undefined) {
+              selectRows(cursorRowIdx, event.shiftKey, event.metaKey);
             }
           }
-          event.preventDefault();
-          event.stopPropagation();
-          return;
-        }
-      }
-      if (key === "Enter") {
-        if (
-          !event.ctrlKey &&
-          !event.metaKey &&
-          !event.altKey &&
-          !event.shiftKey
-        ) {
-          if (cursorRowIdx == undefined) {
-            moveCursor(0, 0);
-          } else {
-            moveCursor(cursorRowIdx + 1, cursorColIdx);
-          }
-          event.preventDefault();
-          event.stopPropagation();
-          return;
-        }
-      }
-      if (key === "Escape") {
-        cancelEditMode();
-        return;
-      }
-      if (key === " ") {
-        if (event.ctrlKey) {
-          if (cursorColIdx != undefined) {
+          break;
+        case "a":
+          if (event.ctrlKey || event.metaKey) {
             rangeSelection.selectRange({
-              start: { rowIdx: 0, colIdx: cursorColIdx },
-              end: { rowIdx: rowData.length, colIdx: cursorColIdx },
+              start: { rowIdx: 0, colIdx: 0 },
+              end: { rowIdx: rowData.length, colIdx: cols.length },
             });
+            selectAll();
           }
-        } else {
-          if (cursorRowIdx != undefined) {
-            selectRows(cursorRowIdx, event.shiftKey, event.metaKey);
-          }
-        }
-        return;
+          break;
+        default:
+          return false;
       }
-      if (key === "c" && (event.ctrlKey || event.metaKey)) {
-        if (!rangeSelection.selectedCellRange) {
-          return;
-        }
+      event.preventDefault();
+      event.stopPropagation();
+      return true;
+    },
+    [
+      rangeSelection.selectRange,
+      rangeSelection.onKeyboardRangeSelectionStart,
+      selectRows,
+      selectAll,
+      cursorColIdx,
+      cursorRowIdx,
+      rowData.length,
+      cols.length,
+    ]
+  );
+
+  const clipboardKeyHandler = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      const { key } = event;
+      if (
+        key === "c" &&
+        (event.ctrlKey || event.metaKey) &&
+        rangeSelection.selectedCellRange
+      ) {
         const { start, end } = rangeSelection.selectedCellRange;
         const c = (x: number, y: number) => x - y;
         const [minRow, maxRow] = [start.rowIdx, end.rowIdx].sort(c);
@@ -759,33 +730,117 @@ export const Grid = function Grid<T>(props: GridProps<T>) {
           text.push(rowText.join("\t"));
         }
         navigator.clipboard.writeText(text.join("\n"));
-        return;
-      }
-      if (key === "a" && (event.ctrlKey || event.metaKey)) {
-        rangeSelection.selectRange({
-          start: { rowIdx: 0, colIdx: 0 },
-          end: { rowIdx: rowData.length, colIdx: cols.length },
-        });
-        selectAll();
         event.preventDefault();
         event.stopPropagation();
-        return;
+        return true;
       }
-      if (
-        !editMode &&
-        !event.ctrlKey &&
-        !event.metaKey &&
-        !event.altKey &&
-        /^[\w\d ]$/.test(key)
-      ) {
-        startEditMode("");
-        return;
-      }
-      // TODO Ctrl + D copies from the first cell to the selection down
-      // TODO Ctrl + R copies from the first cell to the selection right
-      console.log(`onKeyDown unhandled. key=${key}`);
+      return false;
     },
-    [cursorRowIdx, cursorColIdx, moveCursor, startEditMode, rowData, cols]
+    [rangeSelection.selectedCellRange]
+  );
+
+  const navigationKeyHandler = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      const { key } = event;
+      switch (key) {
+        case "ArrowLeft":
+          moveCursor(cursorRowIdx, (cursorColIdx || 0) - 1);
+          break;
+        case "ArrowRight":
+          moveCursor(cursorRowIdx, (cursorColIdx || 0) + 1);
+          break;
+        case "ArrowUp":
+          moveCursor((cursorRowIdx || 0) - 1, cursorColIdx);
+          break;
+        case "ArrowDown":
+          moveCursor((cursorRowIdx || 0) + 1, cursorColIdx);
+          break;
+        case "PageUp":
+          moveCursor((cursorRowIdx || 0) - PAGE_SIZE, cursorColIdx);
+          break;
+        case "PageDown":
+          moveCursor((cursorRowIdx || 0) + PAGE_SIZE, cursorColIdx);
+          break;
+        case "Home":
+          if (!event.ctrlKey) {
+            moveCursor(cursorRowIdx, 0);
+          } else {
+            moveCursor(0, 0);
+          }
+          break;
+        case "End":
+          if (!event.ctrlKey) {
+            moveCursor(cursorRowIdx, cols.length - 1);
+          } else {
+            moveCursor(rowData.length - 1, cols.length - 1);
+          }
+          break;
+        case "Tab":
+          if (!event.ctrlKey && !event.metaKey && !event.altKey) {
+            if (cursorColIdx == undefined || cursorRowIdx == undefined) {
+              moveCursor(0, 0);
+            } else {
+              if (!event.shiftKey) {
+                if (cursorColIdx < cols.length - 1) {
+                  moveCursor(cursorRowIdx, cursorColIdx + 1);
+                } else {
+                  if (cursorRowIdx < rowData.length - 1) {
+                    moveCursor(cursorRowIdx + 1, 0);
+                  }
+                }
+              } else {
+                if (cursorColIdx > 0) {
+                  moveCursor(cursorRowIdx, cursorColIdx - 1);
+                } else {
+                  if (cursorRowIdx > 0) {
+                    moveCursor(cursorRowIdx - 1, cols.length - 1);
+                  }
+                }
+              }
+            }
+          }
+          break;
+        case "Enter":
+          if (
+            !event.ctrlKey &&
+            !event.metaKey &&
+            !event.altKey &&
+            !event.shiftKey
+          ) {
+            if (cursorRowIdx == undefined) {
+              moveCursor(0, 0);
+            } else {
+              moveCursor(cursorRowIdx + 1, cursorColIdx);
+            }
+          }
+          break;
+        default:
+          return false;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      return true;
+    },
+    [moveCursor, cursorRowIdx, cursorRowIdx, cols.length, rowData.length]
+  );
+
+  const onKeyDown: KeyboardEventHandler<HTMLDivElement> = useCallback(
+    (event) => {
+      [
+        navigationKeyHandler,
+        clipboardKeyHandler,
+        selectionKeyHandler,
+        editModeKeyHandler,
+      ].find((handler) => {
+        return handler(event);
+      });
+    },
+    [
+      navigationKeyHandler,
+      clipboardKeyHandler,
+      selectionKeyHandler,
+      editModeKeyHandler,
+    ]
   );
 
   const selectionContext: SelectionContext = useMemo(
@@ -843,7 +898,6 @@ export const Grid = function Grid<T>(props: GridProps<T>) {
                     onKeyDown={onKeyDown}
                     onKeyUp={onKeyUp}
                     onMouseDown={onMouseDown}
-                    // onCopy={onCopy}
                     data-name="grid-root"
                     role="grid"
                   >

--- a/packages/grid/src/GridColumn.tsx
+++ b/packages/grid/src/GridColumn.tsx
@@ -1,14 +1,14 @@
 import {
-  ComponentType,
-  CSSProperties,
-  ReactNode,
-  useEffect,
-  useState,
   Children,
   cloneElement,
+  ComponentType,
+  CSSProperties,
   isValidElement,
-  memo,
+  KeyboardEvent,
+  ReactNode,
+  useEffect,
   useRef,
+  useState,
 } from "react";
 import { useGridContext } from "./GridContext";
 import { GridColumnModel, GridRowModel } from "./Grid";
@@ -104,6 +104,10 @@ export interface GridColumnProps<T = any> {
    * A callback to be invoked when the user modifies a cell value.
    * */
   onChange?: (row: T, rowIndex: number, value: string) => void;
+  /**
+   * A callback to be invoked on key down when the focus is in this column.
+   */
+  onKeyDown?: (event: KeyboardEvent<HTMLDivElement>, rowIndex: number) => void;
   children?: ReactNode;
 }
 

--- a/packages/grid/src/NumericColumn.tsx
+++ b/packages/grid/src/NumericColumn.tsx
@@ -3,7 +3,6 @@ import "./NumericColumn.css";
 import { GridColumnModel, GridRowModel } from "./Grid";
 import {
   ChangeEventHandler,
-  FocusEventHandler,
   KeyboardEventHandler,
   ReactNode,
   useEffect,
@@ -11,21 +10,17 @@ import {
   useState,
 } from "react";
 import { useEditorContext } from "./EditorContext";
-import { CellEditor } from "./CellEditor";
 
 export interface NumericColumnProps<T> extends GridColumnProps<T> {
   precision: number;
 }
 
 function isNumber(value: any): value is number {
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return true;
-  }
-  return false;
+  return typeof value === "number" && Number.isFinite(value);
 }
 
 export function NumericCellValue<T>(props: GridCellValueProps<T>) {
-  const { column, value, row } = props;
+  const { column, value } = props;
   const columnProps = column.info.props as NumericColumnProps<T>;
   const { precision } = columnProps;
   const text = isNumber(value) ? value.toFixed(precision) : "";
@@ -41,12 +36,14 @@ export interface NumericEditorProps<T> {
 export function NumericCellEditor<T>(props: NumericEditorProps<T>) {
   const { column, row } = props;
   const inputRef = useRef<HTMLInputElement>(null);
-  const initialSelectionRef = useRef(false);
+
+  const { endEditMode, cancelEditMode, initialText } = useEditorContext();
+
   const [editorText, setEditorText] = useState<string>(
-    column!.info.props.getValue!(row!.data)
+    initialText || column!.info.props.getValue!(row!.data)
   );
 
-  const { endEditMode, cancelEditMode } = useEditorContext();
+  const initialSelectionRef = useRef(!!initialText);
 
   const onChange: ChangeEventHandler<HTMLInputElement> = (e) => {
     setEditorText(e.target.value);

--- a/packages/grid/src/RowSelectionCheckboxCellValue.tsx
+++ b/packages/grid/src/RowSelectionCheckboxCellValue.tsx
@@ -10,7 +10,7 @@ export function RowSelectionCheckboxCellValue<T>(props: GridCellValueProps<T>) {
 
   const isSelected = selRowIdxs.has(row.index);
   const onMouseDown: MouseEventHandler<HTMLDivElement> = (event) => {
-    selectRows(row.index, false, true);
+    selectRows({ rowIndex: row.index, meta: true });
     event.preventDefault();
     event.stopPropagation();
   };

--- a/packages/grid/src/RowSelectionCheckboxColumn.tsx
+++ b/packages/grid/src/RowSelectionCheckboxColumn.tsx
@@ -19,7 +19,7 @@ export function RowSelectionCheckboxColumn<T>(
     rowIndex: number
   ) => {
     if (event.key === " ") {
-      selectRows(rowIndex, false, true);
+      selectRows({ rowIndex, meta: true });
       event.preventDefault();
       event.stopPropagation();
     }

--- a/packages/grid/src/RowSelectionCheckboxColumn.tsx
+++ b/packages/grid/src/RowSelectionCheckboxColumn.tsx
@@ -1,6 +1,8 @@
+import { KeyboardEvent } from "react";
 import { RowSelectionCheckboxHeaderCell } from "./RowSelectionCheckboxHeaderCell";
 import { RowSelectionCheckboxCellValue } from "./RowSelectionCheckboxCellValue";
 import { GridColumn, GridColumnProps } from "./GridColumn";
+import { useSelectionContext } from "./SelectionContext";
 
 export type RowSelectionCheckboxColumnProps<T> = Omit<
   GridColumnProps<T>,
@@ -10,6 +12,19 @@ export type RowSelectionCheckboxColumnProps<T> = Omit<
 export function RowSelectionCheckboxColumn<T>(
   props: RowSelectionCheckboxColumnProps<T>
 ) {
+  const { selectRows } = useSelectionContext();
+
+  const onKeyDown = (
+    event: KeyboardEvent<HTMLDivElement>,
+    rowIndex: number
+  ) => {
+    if (event.key === " ") {
+      selectRows(rowIndex, false, true);
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  };
+
   return (
     <GridColumn
       {...props}
@@ -17,6 +32,7 @@ export function RowSelectionCheckboxColumn<T>(
       headerComponent={RowSelectionCheckboxHeaderCell}
       cellValueComponent={RowSelectionCheckboxCellValue}
       pinned="left"
+      onKeyDown={onKeyDown}
     />
   );
 }

--- a/packages/grid/src/RowSelectionRadioCellValue.tsx
+++ b/packages/grid/src/RowSelectionRadioCellValue.tsx
@@ -10,7 +10,7 @@ export function RowSelectionRadioCellValue<T>(props: GridCellValueProps<T>) {
 
   const isSelected = selRowIdxs.has(row.index);
   const onMouseDown: MouseEventHandler<HTMLDivElement> = (event) => {
-    selectRows(row.index, false, false);
+    selectRows({ rowIndex: row.index });
     event.preventDefault();
     event.stopPropagation();
   };

--- a/packages/grid/src/RowSelectionRadioColumn.tsx
+++ b/packages/grid/src/RowSelectionRadioColumn.tsx
@@ -19,7 +19,7 @@ export function RowSelectionRadioColumn<T>(
     rowIndex: number
   ) => {
     if (event.key === " ") {
-      selectRows(rowIndex, false, false);
+      selectRows({ rowIndex });
       event.preventDefault();
       event.stopPropagation();
     }

--- a/packages/grid/src/RowSelectionRadioColumn.tsx
+++ b/packages/grid/src/RowSelectionRadioColumn.tsx
@@ -1,6 +1,8 @@
 import { RowSelectionRadioCellValue } from "./RowSelectionRadioCellValue";
 import { GridColumn, GridColumnProps } from "./GridColumn";
 import { RowSelectionRadioHeaderCell } from "./RowSelectionRadioHeaderCell";
+import { useSelectionContext } from "./SelectionContext";
+import { KeyboardEvent } from "react";
 
 export type RowSelectionRadioColumnProps<T> = Omit<
   GridColumnProps<T>,
@@ -10,6 +12,19 @@ export type RowSelectionRadioColumnProps<T> = Omit<
 export function RowSelectionRadioColumn<T>(
   props: RowSelectionRadioColumnProps<T>
 ) {
+  const { selectRows } = useSelectionContext();
+
+  const onKeyDown = (
+    event: KeyboardEvent<HTMLDivElement>,
+    rowIndex: number
+  ) => {
+    if (event.key === " ") {
+      selectRows(rowIndex, false, false);
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  };
+
   return (
     <GridColumn
       {...props}
@@ -17,6 +32,7 @@ export function RowSelectionRadioColumn<T>(
       headerComponent={RowSelectionRadioHeaderCell}
       cellValueComponent={RowSelectionRadioCellValue}
       pinned="left"
+      onKeyDown={onKeyDown}
     />
   );
 }

--- a/packages/grid/src/SelectionContext.ts
+++ b/packages/grid/src/SelectionContext.ts
@@ -6,7 +6,11 @@ export interface SelectionContext {
   selRowIdxs: Set<number>;
   isAnySelected: boolean;
   isAllSelected: boolean;
-  selectRows: (rowIdx: number, shift: boolean, meta: boolean) => void;
+  selectRows: (args: {
+    rowIndex: number;
+    shift?: boolean;
+    meta?: boolean;
+  }) => void;
   selectAll: () => void;
   unselectAll: () => void;
 }

--- a/packages/grid/src/TextCellEditor.tsx
+++ b/packages/grid/src/TextCellEditor.tsx
@@ -1,13 +1,13 @@
 import {
   ChangeEventHandler,
-  FocusEventHandler,
   KeyboardEventHandler,
+  useEffect,
+  useRef,
   useState,
 } from "react";
 import "./TextCellEditor.css";
 import { makePrefixer } from "@jpmorganchase/uitk-core";
 import { useEditorContext } from "./EditorContext";
-import { GridEditorProps } from "./GridColumn";
 import { GridColumnModel, GridRowModel } from "./Grid";
 
 const withBaseName = makePrefixer("uitkGridTextCellEditor");
@@ -19,11 +19,15 @@ export interface TextCellEditorProps<T> {
 
 export function TextCellEditor<T>(props: TextCellEditorProps<T>) {
   const { column, row } = props;
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const { endEditMode, cancelEditMode, initialText } = useEditorContext();
+
   const [editorText, setEditorText] = useState<string>(
-    column!.info.props.getValue!(row!.data)
+    initialText || column!.info.props.getValue!(row!.data)
   );
 
-  const { endEditMode, cancelEditMode } = useEditorContext();
+  const initialSelectionRef = useRef(!!initialText);
 
   const onChange: ChangeEventHandler<HTMLInputElement> = (e) => {
     setEditorText(e.target.value);
@@ -44,10 +48,18 @@ export function TextCellEditor<T>(props: TextCellEditorProps<T>) {
     }
   };
 
+  useEffect(() => {
+    if (inputRef.current && !initialSelectionRef.current) {
+      inputRef.current.select();
+      initialSelectionRef.current = true;
+    }
+  }, [inputRef.current]);
+
   return (
     <td className={withBaseName()}>
       <div className={withBaseName("inputContainer")}>
         <input
+          ref={inputRef}
           autoFocus={true}
           value={editorText}
           onChange={onChange}

--- a/packages/grid/src/__tests__/__e2e__/Grid.cy.tsx
+++ b/packages/grid/src/__tests__/__e2e__/Grid.cy.tsx
@@ -269,8 +269,36 @@ describe("Grid", () => {
     });
   });
 
-  // TODO header virtualization in grouped mode
+  it("Keyboard events should not leak to the parent component", () => {
+    const onKeyDownSpy = cy.stub().as("onKeyDownSpy");
+    cy.mount(
+      <div onKeyDown={onKeyDownSpy}>
+        <GridExample />
+      </div>
+    );
+    clickCell(0, 1);
+    cy.findByRole(`grid`).type("{rightArrow}");
+    cy.findByRole(`grid`).type("{downArrow}");
+    cy.findByRole(`grid`).type("{leftArrow}");
+    cy.findByRole(`grid`).type("{upArrow}");
+    cy.findByRole(`grid`).type("{end}");
+    cy.findByRole(`grid`).type("{home}");
+    cy.findByRole(`grid`).type(" ");
+    cy.get("@onKeyDownSpy").should("not.have.been.called");
+  });
 
-  // TODO column drag-n-drop
-  // TODO clipboard
+  it("Space on checkbox column should toggle selection", () => {
+    cy.mount(<RowSelectionModes />);
+
+    cy.findByLabelText("multi").realClick();
+    findCell(2, 1).click({ force: true });
+    cy.findByRole(`grid`).type("{downArrow}");
+    cy.findByRole(`grid`).type("{leftArrow}");
+    // Space on any other cell would cancel the previous selection and select
+    // the current row. Space on a checkbox cell should add the row to existing
+    // selection.
+    cy.findByRole(`grid`).type(" ");
+    checkRowSelected(2, true);
+    checkRowSelected(3, true);
+  });
 });

--- a/packages/grid/src/internal/ColumnGhost.css
+++ b/packages/grid/src/internal/ColumnGhost.css
@@ -1,7 +1,7 @@
 .uitkGridColumnGhost {
   position: absolute;
-  border: solid 1px var(--uitk-color-blue-500);
-  box-shadow: 6px 6px 10px 10px rgba(0, 0, 0, 0.0967821);
+  border: solid var(--grid-columnGhost-borderWidth) var(--grid-columnGhost-borderColor);
+  box-shadow: var(--grid-columnGhost-boxShadow);
   opacity: 0.85;
 }
 

--- a/packages/grid/src/internal/gridHooks.tsx
+++ b/packages/grid/src/internal/gridHooks.tsx
@@ -1149,7 +1149,10 @@ export function useRangeSelection(cellSelectionMode?: GridCellSelectionMode) {
       return;
     }
     setSelectedCellRange((old) => {
-      const { start } = keyboardSelectionRef.current!;
+      if (!keyboardSelectionRef.current) {
+        return old;
+      }
+      const { start } = keyboardSelectionRef.current;
       const p: CellRange = { start, end: pos };
       return cellRangeEquals(old, p) ? old : p;
     });

--- a/packages/grid/src/internal/gridHooks.tsx
+++ b/packages/grid/src/internal/gridHooks.tsx
@@ -760,6 +760,7 @@ export function useRowSelection<T>(
       }
     },
     [
+      selRowIdxs,
       lastSelRowIdx,
       setSelRowIdxs,
       setLastSelRowIdx,

--- a/packages/grid/src/internal/gridHooks.tsx
+++ b/packages/grid/src/internal/gridHooks.tsx
@@ -712,7 +712,15 @@ export function useRowSelection<T>(
   }, [rowSelectionMode, selRowIdxs, setSelRowIdxs]);
 
   const selectRows = useCallback(
-    (rowIdx: number, shift: boolean, meta: boolean) => {
+    ({
+      rowIndex,
+      shift = false,
+      meta = false,
+    }: {
+      rowIndex: number;
+      shift?: boolean;
+      meta?: boolean;
+    }) => {
       const idxFrom =
         rowSelectionMode === "multi" && lastSelRowIdx !== undefined && shift
           ? lastSelRowIdx
@@ -723,34 +731,34 @@ export function useRowSelection<T>(
 
       if (idxFrom === undefined) {
         if (rowSelectionMode !== "multi" || !meta) {
-          nextSelRowIdxs = new Set([rowIdx]);
-          nextLastSelRowIdx = rowIdx;
+          nextSelRowIdxs = new Set([rowIndex]);
+          nextLastSelRowIdx = rowIndex;
         } else {
           const n = new Set<number>(selRowIdxs);
-          if (n.has(rowIdx)) {
-            n.delete(rowIdx);
+          if (n.has(rowIndex)) {
+            n.delete(rowIndex);
             nextLastSelRowIdx = undefined;
           } else {
-            n.add(rowIdx);
-            nextLastSelRowIdx = rowIdx;
+            n.add(rowIndex);
+            nextLastSelRowIdx = rowIndex;
           }
           nextSelRowIdxs = n;
         }
       } else {
         const s = meta ? new Set<number>(selRowIdxs) : new Set<number>();
-        const idxs = [rowIdx, idxFrom];
+        const idxs = [rowIndex, idxFrom];
         idxs.sort((a, b) => a - b);
         const rowIdxs: number[] = [];
         for (let i = idxs[0]; i <= idxs[1]; ++i) {
           rowIdxs.push(i);
         }
-        if (selRowIdxs.has(rowIdx)) {
+        if (selRowIdxs.has(rowIndex)) {
           rowIdxs.forEach((k) => s.delete(k));
         } else {
           rowIdxs.forEach((k) => s.add(k));
         }
         nextSelRowIdxs = s;
-        nextLastSelRowIdx = rowIdx;
+        nextLastSelRowIdx = rowIndex;
       }
 
       setSelRowIdxs(nextSelRowIdxs);
@@ -795,8 +803,12 @@ export function useRowSelection<T>(
       }
       const target = event.target as HTMLElement;
       try {
-        const [rowIdx] = getCellPosition(target);
-        selectRows(rowIdx, event.shiftKey, event.metaKey || event.ctrlKey);
+        const [rowIndex] = getCellPosition(target);
+        selectRows({
+          rowIndex,
+          shift: event.shiftKey,
+          meta: event.metaKey || event.ctrlKey,
+        });
       } catch (e) {}
     },
     [selectRows, rowSelectionMode]

--- a/packages/grid/stories/grid-cssVariables.stories.tsx
+++ b/packages/grid/stories/grid-cssVariables.stories.tsx
@@ -3,9 +3,7 @@ import {
   ColumnGroup,
   Grid,
   GridColumn,
-  GridProps,
   RowKeyGetter,
-  RowSelectionCheckboxColumn,
   TextCellEditor,
 } from "../src";
 import { ChangeEvent, useMemo, useState } from "react";
@@ -22,7 +20,6 @@ import {
 } from "@jpmorganchase/uitk-core";
 import { DeleteIcon, UndoIcon } from "@jpmorganchase/uitk-icons";
 import "./grid.stories.css";
-import { DefaultIcon } from "@jpmorganchase/uitk-lab/stories/search-input.stories";
 import { Story } from "@storybook/react";
 
 export default {
@@ -194,6 +191,18 @@ const CssVariablesTemplate: Story<{}> = () => {
     {
       name: "--uitkGrid-rowSeparator-color-divided",
       description: "Color of row separators between groups or rows",
+    },
+    {
+      name: "--uitkGrid-columnGhost-borderColor",
+      description: "Border color of the column ghost",
+    },
+    {
+      name: "--uitkGrid-columnGhost-borderWidth",
+      description: "Border width of the column ghost",
+    },
+    {
+      name: "--uitkGrid-columnGhost-boxShadow",
+      description: "Shadow of the column ghost",
     },
   ]);
 

--- a/packages/grid/stories/grid.stories.tsx
+++ b/packages/grid/stories/grid.stories.tsx
@@ -1,6 +1,7 @@
 import { Story } from "@storybook/react";
 import "./grid.stories.css";
 import {
+  CellEditor,
   ColumnGroup,
   DropdownCellEditor,
   Grid,
@@ -29,7 +30,6 @@ import {
   ChevronRightIcon,
   FavoriteIcon,
 } from "../../icons";
-import { CellEditor } from "../src/CellEditor";
 import {
   allLocations,
   createDummyInvestors,


### PR DESCRIPTION
Keyboard navigation refactoring
Space and arrows don't scroll the page
Cell editors fixed (when edit mode initiated by typing)
Space on checkbox/radio column doesn't reset previous selection (it toggles selection on the focused row as expected)
API updated: onKeyDown prop added to GridColumn