### PR TITLE
Split ToolkitContext

### DIFF
--- a/.changeset/moody-falcons-exist.md
+++ b/.changeset/moody-falcons-exist.md
@@ -1,0 +1,5 @@
+---
+"@jpmorganchase/uitk-core": patch
+---
+
+Separate ToolkitContext into Density, Theme and Breakpoint contexts. This will prevent any component where useTheme is used from re-rendering if density updates in the context and vice versa.

--- a/packages/core/src/toolkit-provider/ToolkitProvider.tsx
+++ b/packages/core/src/toolkit-provider/ToolkitProvider.tsx
@@ -10,7 +10,7 @@ import React, {
 } from "react";
 import { AriaAnnouncerProvider } from "../aria-announcer";
 import { Breakpoints, DEFAULT_BREAKPOINTS } from "../breakpoints";
-import { DEFAULT_THEME, Density, getTheme, Theme } from "../theme";
+import { Density, getTheme, Theme } from "../theme";
 import { ViewportProvider } from "../viewport";
 
 export const DEFAULT_DENSITY = "medium";
@@ -36,6 +36,13 @@ declare global {
     }
   }
 }
+
+export const DensityContext = createContext<Density>(DEFAULT_DENSITY);
+
+export const ThemeContext = createContext<Theme[]>([]);
+
+export const BreakpointContext =
+  createContext<Breakpoints>(DEFAULT_BREAKPOINTS);
 
 export const ToolkitContext = createContext<ToolkitContextProps>({
   density: undefined,
@@ -122,8 +129,8 @@ export function ToolkitProvider({
   theme: themesProp,
   breakpoints: breakpointsProp,
 }: ToolkitProviderProps) {
-  const { themes: inheritedThemes, density: inheritedDensity } =
-    useContext(ToolkitContext);
+  const inheritedDensity = useContext(DensityContext);
+  const inheritedThemes = useContext(ThemeContext);
 
   const isRoot =
     inheritedThemes === undefined ||
@@ -141,9 +148,13 @@ export function ToolkitProvider({
   );
 
   const toolkitProvider = (
-    <ToolkitContext.Provider value={{ density, themes, breakpoints }}>
-      <ViewportProvider>{themedChildren}</ViewportProvider>
-    </ToolkitContext.Provider>
+    <DensityContext.Provider value={density}>
+      <ThemeContext.Provider value={themes}>
+        <BreakpointContext.Provider value={breakpoints}>
+          <ViewportProvider>{themedChildren}</ViewportProvider>
+        </BreakpointContext.Provider>
+      </ThemeContext.Provider>
+    </DensityContext.Provider>
   );
 
   if (isRoot) {
@@ -154,19 +165,17 @@ export function ToolkitProvider({
 }
 
 export const useTheme = (): Theme[] => {
-  const { themes = [DEFAULT_THEME] } = useContext(ToolkitContext);
-  return themes;
+  return useContext(ThemeContext);
 };
 
 /**
  * `useDensity` merges density value from 'DensityContext` with the one from component's props.
  */
 export function useDensity(density?: Density): Density {
-  const { density: densityFromContext } = useContext(ToolkitContext);
+  const densityFromContext = useContext(DensityContext);
   return density || densityFromContext || DEFAULT_DENSITY;
 }
 
 export const useBreakpoints = (): Breakpoints => {
-  const { breakpoints } = useContext(ToolkitContext);
-  return breakpoints;
+  return useContext(BreakpointContext);
 };


### PR DESCRIPTION
Separate ToolkitContext into Density, Theme and Breakpoint contexts. This will prevent any component where useTheme is used from re-rendering if density updates in the context and vice versa.