### PR TITLE
Add site publish workflow with preview url comment

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -47,13 +47,27 @@ jobs:
         with:
           script: |
             const previewUrl = "${{ steps.publish.outputs.url }}";
+            const commentText = `Site Preview Link `;
+
+            // Get the existing comments
+            const {data: comments} = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.number,
+            });
+            console.log(111, comments);
+
+            // Find existing comment
+            const oldPreviewUrlComment = comments.find(comment => comment.body.includes(commentText)); 
+
+            console.log(222, oldPreviewUrlComment)
+
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `Site Preview Link ${previewUrl}`
-              idTest: 'test123'
-            })
+              body: `${commentText} ${previewUrl}`
+            });
 
 # get all issue comments
 # if existing comment with 'Site Preview Link' in body get comment id

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -54,7 +54,7 @@ jobs:
               issue_number: context.payload.number,
             });
             const oldPreviewUrlComment = comments.find(comment => comment.body.includes(commentText)); 
-            if(!oldPreviewUrlComment) {
+            if (!oldPreviewUrlComment) {
               github.rest.issues.createComment({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
@@ -63,7 +63,7 @@ jobs:
               });
             } else {
               github.rest.issues.createComment({
-                comment_id: oldPreviewUrlComment.id.
+                comment_id: oldPreviewUrlComment.id,
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -62,7 +62,7 @@ jobs:
                 body: `${commentText} ${previewUrl}`
               });
             } else {
-              github.rest.issues.createComment({
+              github.rest.issues.updateComment({
                 comment_id: oldPreviewUrlComment.id,
                 issue_number: context.issue.number,
                 owner: context.repo.owner,

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -2,8 +2,8 @@ name: Site Publish
 
 on:
   pull_request:
-    branches:
-      - main
+    paths:
+      - "site/**"
 
 jobs:
   deploy:

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -48,28 +48,25 @@ jobs:
           script: |
             const previewUrl = "${{ steps.publish.outputs.url }}";
             const commentText = `Site Preview Link `;
-
-            // Get the existing comments
             const {data: comments} = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.number,
             });
-            console.log(111, comments);
-
-            // Find existing comment
             const oldPreviewUrlComment = comments.find(comment => comment.body.includes(commentText)); 
-
-            console.log(222, oldPreviewUrlComment)
-
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `${commentText} ${previewUrl}`
-            });
-
-# get all issue comments
-# if existing comment with 'Site Preview Link' in body get comment id
-# and update existing comment
-# else create new comment
+            if(!oldPreviewUrlComment) {
+              github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: `${commentText} ${previewUrl}`
+              });
+            } else {
+              github.rest.issues.createComment({
+                comment_id: oldPreviewUrlComment.id.
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: `${commentText} ${previewUrl}`
+              });
+            };

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -52,4 +52,10 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: `Site Preview Link ${previewUrl}`
+              id: 'test123'
             })
+
+# get all issue comments
+# if existing comment with 'Site Preview Link' in body get comment id
+# and update existing comment
+# else create new comment

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -52,7 +52,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: `Site Preview Link ${previewUrl}`
-              id: 'test123'
+              idTest: 'test123'
             })
 
 # get all issue comments

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -1,0 +1,55 @@
+name: Site Publish
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      deployments: write
+      pull-requests: write
+
+    name: Deploy to Cloudflare Pages
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+          cache: "yarn"
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Run build
+        run: yarn build:site
+
+      - name: Publish
+        uses: cloudflare/pages-action@1
+        id: publish
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: "uitk-site"
+          directory: ./site/build
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Preview URL
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const previewUrl = "${{ steps.publish.outputs.url }}";
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Site Preview Link ${previewUrl}`
+            })

--- a/site/docs/components.mdx
+++ b/site/docs/components.mdx
@@ -8,4 +8,4 @@ Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deseru
 
 ## Lorem ipsum
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+Lorem ipsum dolor site amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.


### PR DESCRIPTION
Github workflow added to publish a comment with a preview URL using Cloudflare Pages Direct Uploads 

Still TODO 

- [x] Remove old comment on every push
- [ ] Skip if no changes to /site dir