### PR TITLE
Remove console from Switch and Accordion

### DIFF
--- a/.changeset/famous-tomatoes-scream.md
+++ b/.changeset/famous-tomatoes-scream.md
@@ -1,0 +1,5 @@
+---
+"@jpmorganchase/uitk-lab": patch
+---
+
+Accordion: remove console.log from register handler

--- a/.changeset/witty-zoos-fly.md
+++ b/.changeset/witty-zoos-fly.md
@@ -1,0 +1,5 @@
+---
+"@jpmorganchase/uitk-core": patch
+---
+
+Switch: remove console.log from change handler

--- a/packages/core/src/switch/Switch.tsx
+++ b/packages/core/src/switch/Switch.tsx
@@ -58,7 +58,6 @@ export const Switch = forwardRef<HTMLLabelElement, SwitchProps>(function Switch(
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     const value = event.target.checked;
     setChecked(value);
-    console.log(value);
     onChange?.(event, value);
   };
 

--- a/packages/lab/src/accordion/Accordion.tsx
+++ b/packages/lab/src/accordion/Accordion.tsx
@@ -62,14 +62,6 @@ export const Accordion = forwardRef<HTMLDivElement, AccordionProps>(
 
     const registerSection = useCallback(
       (sectionId: string, isExpanded: boolean) => {
-        if (!sectionId) {
-          debugger;
-        }
-        console.log(
-          `Section "${sectionId}" registered as ${
-            isExpanded ? "expanded" : "collapsed"
-          }`
-        );
         setSectionIds((sectionIds) => {
           const newSectionIds = new Set(sectionIds);
           newSectionIds.add(sectionId);
@@ -87,7 +79,6 @@ export const Accordion = forwardRef<HTMLDivElement, AccordionProps>(
     );
 
     const unregisterSection = useCallback((sectionId: string) => {
-      console.log(`Section "${sectionId}" unregistered`);
       if (expandedSectionIds.includes(sectionId)) {
         setExpandedSectionIds((oldValue) =>
           oldValue.filter((id) => id !== sectionId)


### PR DESCRIPTION
Switch and Accordion is doing `console.log` in handlers, removed in this PR.