### PR TITLE
Color chooser: fix active state swatch size

### DIFF
--- a/.changeset/short-olives-heal.md
+++ b/.changeset/short-olives-heal.md
@@ -1,0 +1,5 @@
+---
+"@jpmorganchase/uitk-lab": patch
+---
+
+Color chooser: fix active state swatch size

--- a/packages/lab/src/color-chooser/Swatch.css
+++ b/packages/lab/src/color-chooser/Swatch.css
@@ -68,8 +68,6 @@
 .uitkColorChooserSwatch-active {
   outline: var(--uitk-container-borderWidth) var(--uitk-container-borderColor-style) var(--uitk-container-borderColor-medium);
   border: var(--uitk-focused-outlineWidth) var(--uitk-container-borderStyle) var(--uitk-actionable-cta-foreground-active) !important;
-  width: calc(var(--colorChooser-swatch-size-unit) - 4px) !important;
-  height: calc(var(--colorChooser-swatch-size-unit) - 4px) !important;
   margin-bottom: 1px;
   margin-left: 1px;
   cursor: pointer;

--- a/packages/lab/stories/color-chooser.qa.stories.tsx
+++ b/packages/lab/stories/color-chooser.qa.stories.tsx
@@ -1,0 +1,28 @@
+import {
+  Color,
+  ColorChooser,
+  getColorPalettes,
+  SwatchesPicker,
+} from "@jpmorganchase/uitk-lab";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { useState } from "react";
+
+export default {
+  title: "Lab/ColorChooser/QA",
+  component: ColorChooser,
+} as ComponentMeta<typeof ColorChooser>;
+
+const allColors = getColorPalettes();
+export const SwatchesPickerQA: ComponentStory<typeof SwatchesPicker> = () => {
+  const [color, setColor] = useState(Color.makeColorFromHex(allColors[7][4]));
+  return (
+    <SwatchesPicker
+      color={color}
+      allColors={allColors}
+      onChange={(c) => setColor(c)}
+      onDialogClosed={() => {
+        console.log("onDialogClosed");
+      }}
+    />
+  );
+};


### PR DESCRIPTION
Current active swatch color is smaller, see below 

![active swatch color size is smaller](https://user-images.githubusercontent.com/5257855/200321192-e4a78a65-147a-4b64-935e-dfd3c4d4ff6d.png)

Fix the style and added a new QA story "Swatches Picker QA"

<img width="429" alt="new swatch qa story" src="https://user-images.githubusercontent.com/5257855/200321374-bfe3f794-5f67-470d-9604-92d91c801d33.png">
