### PR TITLE
Size characteristic changes and opacity update

### DIFF
--- a/.changeset/pink-goats-do.md
+++ b/.changeset/pink-goats-do.md
@@ -4,22 +4,24 @@
 "@jpmorganchase/uitk-theme": minor
 ---
 
---uitk-palette-opacity-background changed to opacity-2
+- --uitk-palette-opacity-background changed to opacity-2
 
-Size tokens updated to use unit calculations where density aware
+- Size tokens updated to use unit calculations where density aware
 
-Pill, Switch, AppHeader, Logo and ToggleGroupButton size tokens moved to respective components:
---uitk-size-adornment -> Input --input-adornment-height
---uitk-size-appHeader --> AppHeader --appHeader-height
---uitk-size-pill -> Pill --pill-height
---uitk-size-switch -> Switch --switch-height
---uitk-size-logo -> Logo --logo-height
---uitk-size-toggleGroupButton -> ToggleGroupButton --toggleButton-group-height
+- The following size tokens moved to become density invariant:
 
-Deleted:
---uitk-size-formField-top
-
-Moved to become density invariant:
 --uitk-size-divider-strokeWidth: 1px;
 --uitk-size-bottomBorder: 2px;
 --uitk-size-brandBar: 4px;
+
+- Pill, Switch, AppHeader, Logo and ToggleGroupButton size tokens moved to respective components
+
+```diff
+- --uitk-size-adornment
+- --uitk-size-appHeader
+- --uitk-size-pill
+- --uitk-size-switch
+- --uitk-size-logo
+- --uitk-size-toggleGroupButton
+- --uitk-size-formField-top
+```

--- a/.changeset/pink-goats-do.md
+++ b/.changeset/pink-goats-do.md
@@ -1,0 +1,25 @@
+---
+"@jpmorganchase/uitk-core": minor
+"@jpmorganchase/uitk-lab": minor
+"@jpmorganchase/uitk-theme": minor
+---
+
+--uitk-palette-opacity-background changed to opacity-2
+
+Size tokens updated to use unit calculations where density aware
+
+Pill, Switch, AppHeader, Logo and ToggleGroupButton size tokens moved to respective components:
+--uitk-size-adornment -> Input --input-adornment-height
+--uitk-size-appHeader --> AppHeader --appHeader-height
+--uitk-size-pill -> Pill --pill-height
+--uitk-size-switch -> Switch --switch-height
+--uitk-size-logo -> Logo --logo-height
+--uitk-size-toggleGroupButton -> ToggleGroupButton --toggleButton-group-height
+
+Deleted:
+--uitk-size-formField-top
+
+Moved to become density invariant:
+--uitk-size-divider-strokeWidth: 1px;
+--uitk-size-bottomBorder: 2px;
+--uitk-size-brandBar: 4px;

--- a/packages/core/src/input/Input.css
+++ b/packages/core/src/input/Input.css
@@ -1,14 +1,18 @@
 /* Styles applied to the root element dependent on density */
 .uitk-density-touch {
+  --input-adornment-height: calc(var(--uitk-size-base) + var(--uitk-size-unit) * 0.5);
   --input-button-inset: 4px;
 }
 .uitk-density-low {
+  --input-adornment-height: calc(var(--uitk-size-base) + var(--uitk-size-unit) * 2 / 3);
   --input-button-inset: 4px;
 }
 .uitk-density-medium {
+  --input-adornment-height: calc(var(--uitk-size-base) + var(--uitk-size-unit) * 0.5);
   --input-button-inset: 2px;
 }
 .uitk-density-high {
+  --input-adornment-height: calc(var(--uitk-size-base) + var(--uitk-size-unit));
   --input-button-inset: 2px;
 }
 
@@ -80,7 +84,7 @@
   display: flex;
   align-items: center;
 
-  height: var(--uitk-size-adornment);
+  height: var(--input-adornment-height);
 }
 
 /* Style applied to root element with start adornment */

--- a/packages/core/src/pill/Pill.css
+++ b/packages/core/src/pill/Pill.css
@@ -20,8 +20,9 @@
   --pill-background-active: var(--uitkPill-background-active, var(--uitk-taggable-background-active));
   --pill-background-disabled: var(--uitkPill-background-disabled, var(--uitk-taggable-background-disabled));
   --pill-background-hover: var(--uitkPill-background-hover, var(--uitk-taggable-background-hover));
-  --pill-checkbox-size: var(--uitkPill-checkbox-size, calc(var(--uitk-size-pill) - 2px));
+  --pill-checkbox-size: var(--uitkPill-checkbox-size, calc(var(--pill-height) - 2px));
   --pill-fontSize: var(--uitkPill-fontSize, var(--uitk-text-caption-fontSize));
+  --pill-height: calc(var(--uitk-size-base) - (var(--uitk-size-unit) * 1.5));
   --pill-icon-color: var(--uitkPill-icon-color, var(--uitk-taggable-foreground));
   --pill-icon-color-active: var(--uitkPill-icon-color-active, var(--uitk-taggable-foreground-active));
   --pill-icon-color-hover: var(--uitkPill-icon-color-hover, var(--uitk-taggable-foreground-hover));
@@ -45,7 +46,7 @@
   color: var(--pill-text-color);
   display: inline-flex;
   font-size: var(--pill-fontSize);
-  height: var(--uitkPill-height, var(--pill-checkbox-size));
+  height: var(--uitkPill-height, var(--pill-checkbox-size)); /* TODO: Check with design vs checkbox height */
   letter-spacing: var(--uitkPill-letterSpacing, 0);
   line-height: var(--uitkPill-lineHeight, var(--uitk-text-base-lineHeight));
   max-width: var(--uitkPill-maxWidth, 160px);
@@ -151,7 +152,7 @@
 /* Style applied to Pill label inner text */
 .uitkPill-innerLabel {
   vertical-align: top;
-  line-height: calc(var(--pill-checkbox-size) + 2px);
+  line-height: var(--pill-height);
 }
 
 /* Style applied to Pill label and icon when `disabled={true}` */

--- a/packages/core/src/switch/Switch.css
+++ b/packages/core/src/switch/Switch.css
@@ -4,7 +4,7 @@
   --switch-thumb-margin: 3px 0 0 3px;
   --switch-thumb-size: 18px;
   --switch-thumb-translate: 20px;
-  --switch-height: calc(var(--uitk-size-base) - var(--uitk-size-selection) + 1.5 * var(--uitk-size-unit));
+  --switch-height: 24px;
 }
 
 .uitk-density-low {
@@ -12,7 +12,7 @@
   --switch-thumb-margin: 2px 0 0 2px;
   --switch-thumb-size: 16px;
   --switch-thumb-translate: 18px;
-  --switch-height: var(--uitk-size-base) - var(--uitk-size-selection) + var(--uitk-size-unit);
+  --switch-height: 20px;
 }
 
 .uitk-density-medium {
@@ -20,7 +20,7 @@
   --switch-thumb-margin: 2px 0 0 2px;
   --switch-thumb-size: 14px;
   --switch-thumb-translate: 16px;
-  --switch-height: var(--uitk-size-base) - var(--uitk-size-selection) + var(--uitk-size-unit);
+  --switch-height: 18px;
 }
 
 .uitk-density-high {
@@ -28,7 +28,7 @@
   --switch-thumb-margin: 2px 0 0 2px;
   --switch-thumb-size: 12px;
   --switch-thumb-translate: 14px;
-  --switch-height: var(--uitk-size-base) - var(--uitk-size-selection) + var(--uitk-size-unit);
+  --switch-height: 16px;
 }
 
 .uitkSwitch {

--- a/packages/core/src/switch/Switch.css
+++ b/packages/core/src/switch/Switch.css
@@ -4,6 +4,7 @@
   --switch-thumb-margin: 3px 0 0 3px;
   --switch-thumb-size: 18px;
   --switch-thumb-translate: 20px;
+  --switch-height: calc(var(--uitk-size-base) - var(--uitk-size-selection) + 1.5 * var(--uitk-size-unit));
 }
 
 .uitk-density-low {
@@ -11,6 +12,7 @@
   --switch-thumb-margin: 2px 0 0 2px;
   --switch-thumb-size: 16px;
   --switch-thumb-translate: 18px;
+  --switch-height: var(--uitk-size-base) - var(--uitk-size-selection) + var(--uitk-size-unit);
 }
 
 .uitk-density-medium {
@@ -18,6 +20,7 @@
   --switch-thumb-margin: 2px 0 0 2px;
   --switch-thumb-size: 14px;
   --switch-thumb-translate: 16px;
+  --switch-height: var(--uitk-size-base) - var(--uitk-size-selection) + var(--uitk-size-unit);
 }
 
 .uitk-density-high {
@@ -25,6 +28,7 @@
   --switch-thumb-margin: 2px 0 0 2px;
   --switch-thumb-size: 12px;
   --switch-thumb-translate: 14px;
+  --switch-height: var(--uitk-size-base) - var(--uitk-size-selection) + var(--uitk-size-unit);
 }
 
 .uitkSwitch {
@@ -43,7 +47,7 @@
   box-sizing: content-box;
   display: inline-flex;
   flex-shrink: 0;
-  height: var(--uitkSwitch-height, var(--uitk-size-switch));
+  height: var(--uitkSwitch-height, var(--switch-height));
   margin-left: 0;
   overflow: visible;
   padding: 0;
@@ -104,7 +108,7 @@
 .uitkSwitch-track {
   background: var(--uitkSwitch-track-color, var(--switch-track-color));
   border-radius: var(--uitkSwitch-track-borderRadius, 0);
-  height: var(--uitkSwitch-track-height, var(--uitk-size-switch));
+  height: var(--uitkSwitch-track-height, var(--switch-height));
   min-height: var(--uitkSwitch-track-minHeight, 16px);
   margin-top: 0;
   margin-left: 0;
@@ -184,7 +188,7 @@
   background: transparent;
   content: "";
   display: block;
-  height: var(--uitkSwitch-focused-height, var(--uitk-size-switch));
+  height: var(--uitkSwitch-focused-height, var(--switch-height));
   left: var(--uitkSwitch-focused-left, -2px);
   outline-style: var(--uitk-focused-outlineStyle);
   outline-width: var(--uitk-focused-outlineWidth);

--- a/packages/lab/src/app-header/AppHeader.css
+++ b/packages/lab/src/app-header/AppHeader.css
@@ -1,6 +1,15 @@
+.uitk-density-medium,
+.uitk-density-low,
+.uitk-density-touch {
+  --appHeader-height: var(--uitkAppHeader-height, calc(var(--uitk-size-base) + var(--uitk-size-unit) * 2));
+}
+
+.uitk-density-high {
+  --appHeader-height: var(--uitkAppHeader-height, calc(var(--uitk-size-base) + var(--uitk-size-unit) * 3));
+}
+
 .uitkAppHeader {
   --appHeader-background: var(--uitk-container-background-medium);
-  --appHeader-height: var(--uitkAppHeader-height, var(--uitk-size-toolbar));
   --appHeader-separable-bar: var(--uitk-separable-secondary-borderColor);
   --appHeader-shadow: var(--uitkAppHeader-shadow, var(--uitk-overlayable-shadow-borderRegion));
   --appHeader-padding: calc(var(--uitk-size-unit) * 3);

--- a/packages/lab/src/logo/Logo.css
+++ b/packages/lab/src/logo/Logo.css
@@ -1,10 +1,22 @@
+.uitk-density-high {
+  --logo-height: var(--uitkLogo-logo-height, 14px);
+}
+.uitk-density-medium {
+  --logo-height: var(--uitkLogo-logo-height, 20px);
+}
+.uitk-density-low {
+  --logo-height: var(--uitkLogo-logo-height, 26px);
+}
+.uitk-density-touch {
+  --logo-height: var(--uitkLogo-logo-height, 32px);
+}
+
 .uitkLogo {
   --logo-color: var(--uitkLogo-color, var(--uitk-palette-neutral-secondary-foreground));
   --logo-divider-color: var(--uitkLogo-pipe-color, var(--uitk-separable-secondary-borderColor));
-  --logo-divider-height: var(--uitkLogo-title-height, var(--uitk-size-inlineDivider));
+  --logo-divider-height: var(--uitkLogo-title-height, var(--uitk-size-divider-height));
   --logo-divider-margin: 0 calc(var(--uitk-size-unit) * 2);
   --logo-fontSize: var(--uitk-text-fontSize);
-  --logo-height: var(--uitkLogo-logo-height, var(--uitk-size-logo));
   --logo-lineHeight: var(--uitk-text-lineHeight);
 }
 

--- a/packages/lab/src/toggle-button/ToggleButtonGroup.css
+++ b/packages/lab/src/toggle-button/ToggleButtonGroup.css
@@ -1,3 +1,16 @@
+.uitk-density-high {
+  --toggleButton-group-height: calc(var(--uitk-size-base) - var(--uitk-size-unit) + 2px);
+}
+.uitk-density-medium {
+  --toggleButton-group-height: calc(var(--uitk-size-base) - (var(--uitk-size-unit) * 0.5) + 2px);
+}
+.uitk-density-low {
+  --toggleButton-group-height: calc(var(--uitk-size-base) - (var(--uitk-size-unit) * 2 / 3) + 2px);
+}
+.uitk-density-touch {
+  --toggleButton-group-height: calc(var(--uitk-size-base) - (var(--uitk-size-unit) * 0.5) + 2px);
+}
+
 .uitkToggleButtonGroup.uitkToggleButtonGroup-cta {
   --toggleButton-group-borderColor: var(--uitkToggleButton-group-cta-borderColor, var(--uitk-container-cta-borderColor));
 }
@@ -20,7 +33,7 @@
 }
 
 .uitkToggleButtonGroup-horizontal .uitkToggleButton {
-  height: var(--uitk-size-toggleGroupButton);
+  height: var(--toggleButton-group-height);
 }
 
 .uitkToggleButtonGroup-horizontal .uitkToggleButton:not(:first-child) {

--- a/packages/theme/css/foundations/palette.css
+++ b/packages/theme/css/foundations/palette.css
@@ -1,7 +1,7 @@
 /* Opacities */
 .uitk-light,
 .uitk-dark {
-  --uitk-palette-opacity-background: var(--uitk-opacity-3);
+  --uitk-palette-opacity-background: var(--uitk-opacity-2);
   --uitk-palette-opacity-border: var(--uitk-opacity-2);
   --uitk-palette-opacity-border-readonly: var(--uitk-opacity-1);
   --uitk-palette-opacity-fill: var(--uitk-opacity-2);

--- a/packages/theme/css/foundations/size.css
+++ b/packages/theme/css/foundations/size.css
@@ -5,75 +5,35 @@
 .uitk-density-high {
   --uitk-size-basis-unit: 4px;
 
+  --uitk-size-bottomBorder: 2px;
+  --uitk-size-brandBar: 4px;
+  --uitk-size-divider-strokeWidth: 1px;
+  --uitk-size-sharktooth-height: 5px;
+  --uitk-size-sharktooth-width: 10px;
+
+  --uitk-size-divider-height: calc(var(--uitk-size-base) - (1.5 * var(--uitk-size-unit)) - (0.5 * var(--uitk-size-basis-unit)));
+  --uitk-size-selection: calc(var(--uitk-size-base) - (1.5 * var(--uitk-size-unit)) - (0.5 * var(--uitk-size-basis-unit)));
+  --uitk-size-stackable: calc(var(--uitk-size-base) + var(--uitk-size-unit));
+
+  /* TODO: Remove on size/density design work completion */
   --uitk-size-graphic-small: 12px;
   --uitk-size-graphic-medium: 24px;
   --uitk-size-graphic-large: 48px;
-
-  --uitk-size-sharktooth-height: 5px;
-  --uitk-size-sharktooth-width: 10px;
 }
 
-.uitk-density-touch {
-  --uitk-size-unit: calc(var(--uitk-size-basis-unit) * 4);
-  --uitk-size-base: 44px;
-  --uitk-size-adornment: calc(var(--uitk-size-base) + var(--uitk-size-unit) * 0.5);
-  --uitk-size-appHeader: calc(var(--uitk-size-base) + var(--uitk-size-unit) * 2);
-  --uitk-size-bottomBorder: 2px;
-  --uitk-size-brandBar: calc(var(--uitk-size-unit) * 0.25);
-  --uitk-size-formField-top: calc(var(--uitk-size-base) + var(--uitk-size-unit) * 1.5);
-  --uitk-size-inlineDivider: calc(var(--uitk-size-base) - 26px);
-  --uitk-size-logo: 32px;
-  --uitk-size-pill: calc(var(--uitk-size-base) - (var(--uitk-size-unit) * 1.5));
-  --uitk-size-selection: 26px;
-  --uitk-size-stackable: calc(var(--uitk-size-base) + var(--uitk-size-unit));
-  --uitk-size-switch: calc(var(--uitk-size-base) - var(--uitk-size-selection) + 6px);
-  --uitk-size-toggleGroupButton: calc(var(--uitk-size-base) - (var(--uitk-size-unit) * 0.5) + 2px);
-}
-.uitk-density-low {
-  --uitk-size-unit: calc(var(--uitk-size-basis-unit) * 3);
-  --uitk-size-base: 36px;
-  --uitk-size-adornment: calc(var(--uitk-size-base) + var(--uitk-size-unit) * 2 / 3);
-  --uitk-size-appHeader: calc(var(--uitk-size-base) + var(--uitk-size-unit) * 2);
-  --uitk-size-bottomBorder: 2px;
-  --uitk-size-brandBar: calc(var(--uitk-size-unit) / 3);
-  --uitk-size-formField-top: calc(var(--uitk-size-base) + var(--uitk-size-unit) * 1.5);
-  --uitk-size-inlineDivider: calc(var(--uitk-size-base) - 20px);
-  --uitk-size-logo: 26px;
-  --uitk-size-pill: calc(var(--uitk-size-base) - var(--uitk-size-unit) * 1.5);
-  --uitk-size-selection: 20px;
-  --uitk-size-stackable: calc(var(--uitk-size-base) + var(--uitk-size-unit));
-  --uitk-size-switch: calc(var(--uitk-size-base) - var(--uitk-size-selection) + 4px);
-  --uitk-size-toggleGroupButton: calc(var(--uitk-size-base) - (var(--uitk-size-unit) * 2 / 3) + 2px);
+.uitk-density-high {
+  --uitk-size-unit: calc(var(--uitk-size-basis-unit) * 1);
+  --uitk-size-base: calc(var(--uitk-size-basis-unit) * 5);
 }
 .uitk-density-medium {
   --uitk-size-unit: calc(var(--uitk-size-basis-unit) * 2);
-  --uitk-size-base: 28px;
-  --uitk-size-adornment: calc(var(--uitk-size-base) + var(--uitk-size-unit) * 0.5);
-  --uitk-size-appHeader: calc(var(--uitk-size-base) + var(--uitk-size-unit) * 2);
-  --uitk-size-bottomBorder: 2px;
-  --uitk-size-brandBar: calc(var(--uitk-size-unit) * 0.5);
-  --uitk-size-formField-top: calc(var(--uitk-size-base) + var(--uitk-size-unit) * 2);
-  --uitk-size-inlineDivider: calc(var(--uitk-size-base) - 14px);
-  --uitk-size-logo: 20px;
-  --uitk-size-pill: calc(var(--uitk-size-base) - var(--uitk-size-unit) * 1.5);
-  --uitk-size-selection: 14px;
-  --uitk-size-stackable: calc(var(--uitk-size-base) + var(--uitk-size-unit));
-  --uitk-size-switch: calc(var(--uitk-size-base) - var(--uitk-size-selection) + 4px);
-  --uitk-size-toggleGroupButton: calc(var(--uitk-size-base) - (var(--uitk-size-unit) * 0.5) + 2px);
+  --uitk-size-base: calc(var(--uitk-size-basis-unit) * 7);
 }
-.uitk-density-high {
-  --uitk-size-unit: var(--uitk-size-basis-unit);
-  --uitk-size-base: 20px;
-  --uitk-size-adornment: calc(var(--uitk-size-base) + var(--uitk-size-unit));
-  --uitk-size-appHeader: calc(var(--uitk-size-base) + var(--uitk-size-unit) * 3);
-  --uitk-size-bottomBorder: 2px;
-  --uitk-size-brandBar: var(--uitk-size-unit);
-  --uitk-size-formField-top: calc(var(--uitk-size-base) + var(--uitk-size-unit) * 4);
-  --uitk-size-inlineDivider: calc(var(--uitk-size-base) - 8px);
-  --uitk-size-logo: 14px;
-  --uitk-size-pill: calc(var(--uitk-size-base) - var(--uitk-size-unit) * 1.5);
-  --uitk-size-selection: 8px;
-  --uitk-size-stackable: calc(var(--uitk-size-base) + var(--uitk-size-unit));
-  --uitk-size-switch: calc(var(--uitk-size-base) - var(--uitk-size-selection) + 4px);
-  --uitk-size-toggleGroupButton: calc(var(--uitk-size-base) - var(--uitk-size-unit) + 2px);
+.uitk-density-low {
+  --uitk-size-unit: calc(var(--uitk-size-basis-unit) * 3);
+  --uitk-size-base: calc(var(--uitk-size-basis-unit) * 9);
+}
+.uitk-density-touch {
+  --uitk-size-unit: calc(var(--uitk-size-basis-unit) * 4);
+  --uitk-size-base: calc(var(--uitk-size-basis-unit) * 11);
 }

--- a/packages/theme/stories/foundations/foundations.stories.mdx
+++ b/packages/theme/stories/foundations/foundations.stories.mdx
@@ -15,7 +15,7 @@ Foundation design tokens should generally be in the format `--uitk-<foundation n
 
 1. Always begin with `--uitk-`
 2. Follow this by the **_foundation name_**, e.g. `---uitk-color-`, `---uitk-shadow-`, `--uitk-size-`, `--uitk-typography-`
-3. Append the **_intent_**, if applicable: e.g. `--uitk-color-blue-`, `--uitk-shadow-elevation-`, `--uitk-size-toggleGroupButton`, `--uitk-typography-fontWeight-`
+3. Append the **_intent_**, if applicable: e.g. `--uitk-color-blue-`, `--uitk-shadow-elevation-`, `--uitk-size-stackable`, `--uitk-typography-fontWeight-`
 4. Append the **_scale_** or **_rank_**, if applicable: e.g. `--uitk-color-blue-700`, `--uitk-shadow-elevation-3`, `--uitk-typography-fontWeight-light`
 
 ## Using Foundations

--- a/packages/theme/stories/foundations/size.stories.mdx
+++ b/packages/theme/stories/foundations/size.stories.mdx
@@ -14,11 +14,11 @@ All size values are based on 4px, `--uitk-size-basis-unit`. If you need to chang
   <Story name="Density Invariant">
     <DocGrid>
       <SpacingBlock spacingVar="--uitk-size-basis-unit" />
-      <SpacingBlock spacingVar="--uitk-size-graphic-small" />
-      <SpacingBlock spacingVar="--uitk-size-graphic-medium" />
-      <SpacingBlock spacingVar="--uitk-size-graphic-large" />
-      <SpacingBlock spacingVar="--uitk-size-sharktooth-width" />
+      <SpacingBlock spacingVar="--uitk-size-bottomBorder" />
+      <SpacingBlock spacingVar="--uitk-size-brandBar" />
+      <SpacingBlock spacingVar="--uitk-size-divider-strokeWidth" />
       <SpacingBlock spacingVar="--uitk-size-sharktooth-height" />
+      <SpacingBlock spacingVar="--uitk-size-sharktooth-width" />
     </DocGrid>
   </Story>
 </Canvas>
@@ -30,19 +30,9 @@ All size values are based on 4px, `--uitk-size-basis-unit`. If you need to chang
     <DocGrid>
       <SpacingBlock spacingVar="--uitk-size-unit" />
       <SpacingBlock spacingVar="--uitk-size-base" />
-      <SpacingBlock spacingVar="--uitk-size-adornment" />
-      <SpacingBlock spacingVar="--uitk-size-appHeader" />
-      <SpacingBlock spacingVar="--uitk-size-bottomBorder" />
-      <SpacingBlock spacingVar="--uitk-size-brandBar" />
-      <SpacingBlock spacingVar="--uitk-size-formField-top" />
-      <SpacingBlock spacingVar="--uitk-size-inlineDivider" />
-      <SpacingBlock spacingVar="--uitk-size-logo" />
-      <SpacingBlock spacingVar="--uitk-size-pill" />
+      <SpacingBlock spacingVar="--uitk-size-divider-height" />
       <SpacingBlock spacingVar="--uitk-size-selection" />
       <SpacingBlock spacingVar="--uitk-size-stackable" />
-      <SpacingBlock spacingVar="--uitk-size-switch" />
-      <SpacingBlock spacingVar="--uitk-size-toggleGroupButton" />
-      <SpacingBlock spacingVar="--uitk-size-toolbar" />
     </DocGrid>
   </Story>
 </Canvas>


### PR DESCRIPTION
- --uitk-palette-opacity-background fixed to be correct opacity

- Size tokens updated to use unit calculations where density aware

- Pill, Switch, AppHeader, Logo and ToggleGroupButton size tokens moved to respective components:

--uitk-size-adornment -> Input --input-adornment-height
--uitk-size-appHeader --> AppHeader --appHeader-height
--uitk-size-pill -> Pill --pill-height
--uitk-size-switch -> Switch --switch-height
--uitk-size-logo -> Logo --logo-height
--uitk-size-toggleGroupButton -> ToggleGroupButton --toggleGroupButton-height

- Deleted:

--uitk-size-formField-top

- Moved to become density invariant:

--uitk-size-separator: 1px;
--uitk-size-bottomBorder: 2px;
--uitk-size-brandBar: 4px;