### PR TITLE
Update styles for Column drag-and-drop and fix escape key not cancelling column move

### DIFF
--- a/.changeset/witty-parrots-roll.md
+++ b/.changeset/witty-parrots-roll.md
@@ -1,0 +1,6 @@
+---
+"@jpmorganchase/uitk-grid": patch
+---
+
+Updated styles for column drag-and-drop
+Escape key pressed while dragging a column cancels column move

--- a/packages/grid/src/Grid.css
+++ b/packages/grid/src/Grid.css
@@ -133,7 +133,6 @@
   --grid-groupHeader-color: var(--uitkGrid-groupHeader-color, var(--grid-groupHeader-color-default));
   --grid-shadow-color: var(--uitkGrid-shadow-color, var(--grid-shadow-color-default));
   --grid-columnDropTarget-color: var(--uitkGrid-columnDropTarget-color, var(--grid-columnDropTarget-color-default));
-  --grid-columnDropTarget-width: var(--uitkGrid-columnDropTarget-width, 2px);
   --grid-cursor-border-style: var(--uitkGrid-cursor-borderStyle, dotted);
   --grid-cursor-border-width: var(--uitkGrid-cursor-borderWidth, 2px);
   --grid-cursor-borderColor: var(--uitkGrid-cursor-borderColor, var(--grid-cursor-borderColor-default));
@@ -147,12 +146,6 @@
   --grid-columnGhost-borderColor: var(--uitkGrid-columnGhost-borderColor, var(--uitk-palette-interact-border-hover));
   --grid-columnGhost-borderWidth: var(--uitkGrid-columnGhost-borderWidth, 1px);
   --grid-columnGhost-boxShadow: var(--uitkGrid-columnGhost-boxShadow, var(--uitk-overlayable-shadow-drag));
-}
-
-.uitkGrid {
-  position: relative;
-  outline: none;
-  user-select: none;
 }
 
 .uitkGrid-columnSeparators {
@@ -169,12 +162,19 @@
 
 /* Styles applied to the root element if variant="primary" */
 .uitkGrid-primaryBackground {
-  background: var(--grid-background-primary);
+  --grid-background: var(--grid-background-primary);
 }
 
 /* Styles applied to the root element if variant="secondary" */
 .uitkGrid-secondaryBackground {
-  background: var(--grid-background-secondary);
+  --grid-background: var(--grid-background-secondary);
+}
+
+.uitkGrid {
+  position: relative;
+  outline: none;
+  user-select: none;
+  background: var(--grid-background);
 }
 
 /* Styles applied to the root element if zebra is enabled */

--- a/packages/grid/src/Grid.tsx
+++ b/packages/grid/src/Grid.tsx
@@ -976,12 +976,12 @@ export const Grid = function Grid<T>(props: GridProps<T>) {
                         isRaised={isRightRaised}
                       />
                     )}
+                    <ColumnDropTarget x={activeTarget?.x} />
                     <ColumnGhost
                       columns={cols}
                       rows={rows}
                       dragState={dragState}
                     />
-                    <ColumnDropTarget x={activeTarget?.x} />
                   </div>
                 </EditorContext.Provider>
               </SizingContext.Provider>

--- a/packages/grid/src/Grid.tsx
+++ b/packages/grid/src/Grid.tsx
@@ -981,6 +981,7 @@ export const Grid = function Grid<T>(props: GridProps<T>) {
                       columns={cols}
                       rows={rows}
                       dragState={dragState}
+                      zebra={zebra}
                     />
                   </div>
                 </EditorContext.Provider>

--- a/packages/grid/src/Grid.tsx
+++ b/packages/grid/src/Grid.tsx
@@ -569,18 +569,22 @@ export const Grid = function Grid<T>(props: GridProps<T>) {
     }
   };
 
-  const { dragState, onColumnMoveHandleMouseDown, activeTarget } =
-    useColumnMove(
-      columnMove,
-      rootRef,
-      leftCols,
-      midCols,
-      rightCols,
-      cols,
-      scrollLeft,
-      clientMidWidth,
-      onColumnMove
-    );
+  const {
+    dragState,
+    onColumnMoveHandleMouseDown,
+    activeTarget,
+    onColumnMoveCancel,
+  } = useColumnMove(
+    columnMove,
+    rootRef,
+    leftCols,
+    midCols,
+    rightCols,
+    cols,
+    scrollLeft,
+    clientMidWidth,
+    onColumnMove
+  );
 
   const columnDragContext: ColumnDragContext = useMemo(
     () => ({
@@ -626,8 +630,12 @@ export const Grid = function Grid<T>(props: GridProps<T>) {
           startEditMode();
           break;
         case "Escape":
-          cancelEditMode();
-          break;
+          if (editMode) {
+            cancelEditMode();
+            break;
+          } else {
+            return false;
+          }
         default:
           if (
             !editMode &&
@@ -822,6 +830,20 @@ export const Grid = function Grid<T>(props: GridProps<T>) {
     [moveCursor, cursorRowIdx, cursorRowIdx, cols.length, rowData.length]
   );
 
+  const columnMoveKeyHandler = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      const { key } = event;
+      if (key === "Escape") {
+        onColumnMoveCancel();
+        event.preventDefault();
+        event.stopPropagation();
+        return true;
+      }
+      return false;
+    },
+    []
+  );
+
   const onKeyDown: KeyboardEventHandler<HTMLDivElement> = useCallback(
     (event) => {
       if (cursorColIdx != undefined && cursorRowIdx != undefined) {
@@ -836,6 +858,7 @@ export const Grid = function Grid<T>(props: GridProps<T>) {
           clipboardKeyHandler,
           selectionKeyHandler,
           editModeKeyHandler,
+          columnMoveKeyHandler,
         ].find((handler) => {
           return handler(event);
         });
@@ -846,6 +869,7 @@ export const Grid = function Grid<T>(props: GridProps<T>) {
       clipboardKeyHandler,
       selectionKeyHandler,
       editModeKeyHandler,
+      columnMoveKeyHandler,
     ]
   );
 

--- a/packages/grid/src/internal/ColumnDropTarget.css
+++ b/packages/grid/src/internal/ColumnDropTarget.css
@@ -2,6 +2,8 @@
   position: absolute;
   top: 0;
   bottom: 0;
-  width: var(--grid-columnDropTarget-width);
-  background: var(--grid-columnDropTarget-color);
+  width: 3px;
+  border: var(--grid-columnDropTarget-color);
+  border-width: 0 1px 0 1px;
+  border-style: solid;
 }

--- a/packages/grid/src/internal/ColumnDropTarget.tsx
+++ b/packages/grid/src/internal/ColumnDropTarget.tsx
@@ -15,7 +15,7 @@ export function ColumnDropTarget(props: ColumnDropTargetProps) {
 
   const style = useMemo(() => {
     return {
-      left: `${x}px`,
+      left: `${x - 2}px`,
     };
   }, [x]);
 

--- a/packages/grid/src/internal/ColumnGhost.css
+++ b/packages/grid/src/internal/ColumnGhost.css
@@ -1,4 +1,5 @@
 .uitkGridColumnGhost {
+  background: var(--grid-background);
   position: absolute;
   border: solid var(--grid-columnGhost-borderWidth) var(--grid-columnGhost-borderColor);
   box-shadow: var(--grid-columnGhost-boxShadow);

--- a/packages/grid/src/internal/ColumnGhost.tsx
+++ b/packages/grid/src/internal/ColumnGhost.tsx
@@ -13,6 +13,7 @@ export interface ColumnGhostProps<T> {
   dragState?: ColumnDragState;
   columns: GridColumnModel<T>[];
   rows: GridRowModel<T>[];
+  zebra?: boolean;
 }
 
 // When the user drags a column this component renders a partially transparent
@@ -23,7 +24,7 @@ export function ColumnGhost<T = any>(props: ColumnGhostProps<T>) {
   }
 
   const { columnIndex, x, y } = props.dragState;
-  const { columns, rows } = props;
+  const { columns, rows, zebra } = props;
   const movingColumn = columns[columnIndex];
 
   const style: CSSProperties = {
@@ -42,6 +43,7 @@ export function ColumnGhost<T = any>(props: ColumnGhostProps<T>) {
           columns={[movingColumn]}
           rows={rows}
           setHoverRowKey={() => {}}
+          zebra={zebra}
         />
       </table>
     </div>

--- a/packages/grid/src/internal/gridHooks.tsx
+++ b/packages/grid/src/internal/gridHooks.tsx
@@ -983,6 +983,12 @@ export function useColumnMove<T = any>(
       [columnDragStart, cols]
     );
 
+  const onColumnMoveCancel = useCallback(() => {
+    setDragState(undefined);
+    moveRef.current?.unsubscribe();
+    moveRef.current = undefined;
+  }, [setDragState]);
+
   const targets = useMemo(() => {
     if (!dragState) {
       return undefined;
@@ -1044,7 +1050,12 @@ export function useColumnMove<T = any>(
 
   activeTargetRef.current = activeTarget;
 
-  return { onColumnMoveHandleMouseDown, dragState, activeTarget };
+  return {
+    onColumnMoveHandleMouseDown,
+    dragState,
+    activeTarget,
+    onColumnMoveCancel,
+  };
 }
 
 export interface CellPosition {


### PR DESCRIPTION
Updated styles of column ghost (appears when column is moved using drag-and-drop) and column drop targets.
Escape cancels column move.