### PR TITLE
Rename ratable border color token

### DIFF
--- a/.changeset/rare-coats-talk.md
+++ b/.changeset/rare-coats-talk.md
@@ -1,0 +1,20 @@
+---
+"@jpmorganchase/uitk-lab": minor
+"@jpmorganchase/uitk-theme": minor
+---
+
+Ratable characteristics border color token naming aligns with others.
+
+```diff
+- --uitk-ratable-border
+- --uitk-ratable-border-active
+- --uitk-ratable-border-disabled
+- --uitk-ratable-border-hover
+- --uitk-ratable-border-undo
+
++ --uitk-ratable-borderColor
++ --uitk-ratable-borderColor-active
++ --uitk-ratable-borderColor-disabled
++ --uitk-ratable-borderColor-hover
++ --uitk-ratable-borderColor-undo
+```

--- a/packages/lab/src/contact-details/ContactDetails.css
+++ b/packages/lab/src/contact-details/ContactDetails.css
@@ -261,7 +261,7 @@
 }
 
 .uitkContactFavoriteToggle-deselected {
-  --contactDetails-favoriteToggle-fill: var(--uitk-ratable-border);
+  --contactDetails-favoriteToggle-fill: var(--uitk-ratable-borderColor);
 }
 
 .uitkContactFavoriteToggle-selecting {
@@ -273,7 +273,7 @@
 }
 
 .uitkContactFavoriteToggle-deselecting {
-  --contactDetails-favoriteToggle-fill: var(--uitk-ratable-border);
+  --contactDetails-favoriteToggle-fill: var(--uitk-ratable-borderColor);
 }
 
 .uitkContactFavoriteToggle-svg {

--- a/packages/theme/css/characteristics/ratable.css
+++ b/packages/theme/css/characteristics/ratable.css
@@ -17,9 +17,9 @@
   --uitk-ratable-background-hover: var(--uitk-palette-rate-background-hover);
   --uitk-ratable-background-undo: var(--uitk-palette-rate-background-undo);
 
-  --uitk-ratable-border: var(--uitk-palette-rate-border);
-  --uitk-ratable-border-active: var(--uitk-palette-rate-border-active);
-  --uitk-ratable-border-disabled: var(--uitk-palette-rate-border-disabled);
-  --uitk-ratable-border-hover: var(--uitk-palette-rate-border-hover);
-  --uitk-ratable-border-undo: var(--uitk-palette-rate-border-undo);
+  --uitk-ratable-borderColor: var(--uitk-palette-rate-border);
+  --uitk-ratable-borderColor-active: var(--uitk-palette-rate-border-active);
+  --uitk-ratable-borderColor-disabled: var(--uitk-palette-rate-border-disabled);
+  --uitk-ratable-borderColor-hover: var(--uitk-palette-rate-border-hover);
+  --uitk-ratable-borderColor-undo: var(--uitk-palette-rate-border-undo);
 }

--- a/packages/theme/stories/characteristics/ratable.stories.mdx
+++ b/packages/theme/stories/characteristics/ratable.stories.mdx
@@ -35,11 +35,11 @@ Components that can be rated.
       <ColorBlock colorVar="--uitk-ratable-background-active" />
       <ColorBlock colorVar="--uitk-ratable-background-activeDisabled" />
       <ColorBlock colorVar="--uitk-ratable-background-undo" />
-      <ColorBlock colorVar="--uitk-ratable-border" />
-      <ColorBlock colorVar="--uitk-ratable-border-hover" />
-      <ColorBlock colorVar="--uitk-ratable-border-active" />
-      <ColorBlock colorVar="--uitk-ratable-border-undo" />
-      <ColorBlock colorVar="--uitk-ratable-border-disabled" />
+      <ColorBlock colorVar="--uitk-ratable-borderColor" />
+      <ColorBlock colorVar="--uitk-ratable-borderColor-hover" />
+      <ColorBlock colorVar="--uitk-ratable-borderColor-active" />
+      <ColorBlock colorVar="--uitk-ratable-borderColor-undo" />
+      <ColorBlock colorVar="--uitk-ratable-borderColor-disabled" />
     </DocGrid>
   </Story>
 </Canvas>


### PR DESCRIPTION
Ratable is the only characteristic having `border` not `borderColor` in border color naming. e.g. search `-border(-\w+)?:` in `./packages/theme/css/characteristics` folder v.s. search `-borderColor(-\w+)?:`.

Palette color tokens (e.g. `--uitk-palette-rate-border`, `--uitk-palette-neutral-cta-border`) are having `border` as names which is worth a separate discussion. 