### PR TITLE
Fix theme editor build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,3 +132,19 @@ jobs:
       - name: Run Playwright
         run: xvfb-run yarn test
         working-directory: ./playground/electron-testing-app
+
+  # We need this to ensure apps build in playground folder doesn't break, mostly due to modular patches
+  playground-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+          cache: "yarn"
+      - name: Install dependencies
+        run: yarn
+      - name: Build theme editor
+        run: yarn modular build @jpmorganchase/theme-editor-app

--- a/.yarn/patches/modular-scripts-npm-3.4.0-8cdb747f13.patch
+++ b/.yarn/patches/modular-scripts-npm-3.4.0-8cdb747f13.patch
@@ -12,15 +12,31 @@ index 862bc50e7be846106cd3647be9dd50f747eb2b15..9f78bf7620f32e4044a2d9b58a4f555b
        noEmit: true
      }
 diff --git a/dist-cjs/utils/getPackageMetadata.js b/dist-cjs/utils/getPackageMetadata.js
-index f77a29810ef1ccaf429c0ea69f9154a2da1ea6ce..9677fbddefa821702ddd464239aff3236b4fd125 100644
+index f77a29810ef1ccaf429c0ea69f9154a2da1ea6ce..ab2e6a04343382101c12d763dcf3cf8c239fdbfc 100644
 --- a/dist-cjs/utils/getPackageMetadata.js
 +++ b/dist-cjs/utils/getPackageMetadata.js
-@@ -64,7 +64,7 @@ async function getPackageMetadata() {
+@@ -64,7 +64,8 @@ async function getPackageMetadata() {
    Object.assign(typescriptConfig, configObject, {
      // TODO: should probably include the original exclude in this
      exclude: distinct([// all TS test files, regardless whether co-located or in test/ etc
 -    '**/*.stories.ts', '**/*.stories.tsx', '**/*.spec.ts', '**/*.test.ts', '**/*.e2e.ts', '**/*.spec.tsx', '**/*.test.tsx', '**/__tests__', '**/dist-cjs', '**/dist-es', '**/dist-types', // TS defaults below
++    // We removed stories.tsx? from modular
 +    '**/*.spec.ts', '**/*.test.ts', '**/*.e2e.ts', '**/*.spec.tsx', '**/*.test.tsx', '**/__tests__', '**/dist-cjs', '**/dist-es', '**/dist-types', // TS defaults below
      'node_modules', 'bower_components', 'jspm_packages', 'tmp', // Casting so that configObject.exclude is set to the correct typing
      // Since configObject is a index type all values are "any" implicitly.
      ...(configObject.exclude || [])])
+diff --git a/react-scripts/config/paths.js b/react-scripts/config/paths.js
+index 5587b7cda8a2841b4fd7c2950127cc3a102f3f19..e4ea664a9d0cc312d7b4c42c631aa8ec004022fd 100644
+--- a/react-scripts/config/paths.js
++++ b/react-scripts/config/paths.js
+@@ -88,6 +88,10 @@ module.exports = {
+   appSrc: resolveApp('src'),
+   modularSrc: [
+     resolveModular('packages'),
++    // Needed to make `modular start app` to work, so webpack can resolve ts/tsx files, see more around `paths.modularSrc` in
++    // node_modules/modular-scripts/react-scripts/config/parts/baseConfig.js
++    resolveModular('playground'),
++    resolveModular('tooling'),
+     resolveModular('node_modules/.modular'),
+   ],
+   appTsConfig: resolveApp('tsconfig.json'),

--- a/playground/theme-editor-app/package.json
+++ b/playground/theme-editor-app/package.json
@@ -6,9 +6,9 @@
     "type": "app"
   },
   "dependencies": {
+    "@jpmorganchase/theme-editor": "*",
     "@jpmorganchase/uitk-core": "*",
     "@jpmorganchase/uitk-lab": "*",
-    "@jpmorganchase/uitk-theme": "*",
-    "@jpmorganchase/theme-editor": ">=1.0.0"
+    "@jpmorganchase/uitk-theme": "*"
   }
 }

--- a/playground/theme-editor-app/package.json
+++ b/playground/theme-editor-app/package.json
@@ -6,6 +6,9 @@
     "type": "app"
   },
   "dependencies": {
+    "@jpmorganchase/uitk-core": "*",
+    "@jpmorganchase/uitk-lab": "*",
+    "@jpmorganchase/uitk-theme": "*",
     "@jpmorganchase/theme-editor": ">=1.0.0"
   }
 }

--- a/playground/theme-editor-app/src/ThemeEditorApp.d.ts
+++ b/playground/theme-editor-app/src/ThemeEditorApp.d.ts
@@ -1,5 +1,5 @@
 import React from "react";
-import { JSONObj } from "theme-editor/src/ThemeEditor";
+import { JSONObj } from "@jpmorganchase/theme-editor/src/ThemeEditor";
 import "@jpmorganchase/uitk-theme/index.css";
 import "./App.css";
 export declare type JSONByScope = {

--- a/playground/theme-editor-app/tsconfig.json
+++ b/playground/theme-editor-app/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "../../tsconfig.json"
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3758,7 +3758,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jpmorganchase/theme-editor-app@workspace:playground/theme-editor-app"
   dependencies:
-    "@jpmorganchase/theme-editor": ">=1.0.0"
+    "@jpmorganchase/theme-editor": "*"
+    "@jpmorganchase/uitk-core": "*"
+    "@jpmorganchase/uitk-lab": "*"
+    "@jpmorganchase/uitk-theme": "*"
   languageName: unknown
   linkType: soft
 
@@ -3773,7 +3776,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@jpmorganchase/theme-editor@>=1.0.0, @jpmorganchase/theme-editor@workspace:tooling/theme-editor":
+"@jpmorganchase/theme-editor@*, @jpmorganchase/theme-editor@>=1.0.0, @jpmorganchase/theme-editor@workspace:tooling/theme-editor":
   version: 0.0.0-use.local
   resolution: "@jpmorganchase/theme-editor@workspace:tooling/theme-editor"
   dependencies:
@@ -3790,7 +3793,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@jpmorganchase/uitk-core@workspace:packages/core":
+"@jpmorganchase/uitk-core@*, @jpmorganchase/uitk-core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@jpmorganchase/uitk-core@workspace:packages/core"
   peerDependencies:
@@ -3832,7 +3835,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@jpmorganchase/uitk-lab@workspace:packages/lab":
+"@jpmorganchase/uitk-lab@*, @jpmorganchase/uitk-lab@workspace:packages/lab":
   version: 0.0.0-use.local
   resolution: "@jpmorganchase/uitk-lab@workspace:packages/lab"
   peerDependencies:
@@ -3845,7 +3848,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@jpmorganchase/uitk-theme@workspace:packages/theme":
+"@jpmorganchase/uitk-theme@*, @jpmorganchase/uitk-theme@workspace:packages/theme":
   version: 0.0.0-use.local
   resolution: "@jpmorganchase/uitk-theme@workspace:packages/theme"
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -19068,7 +19068,7 @@ __metadata:
 
 "modular-scripts@patch:modular-scripts@npm:3.4.0#.yarn/patches/modular-scripts-npm-3.4.0-8cdb747f13.patch::locator=%40jpmorganchase%2Froot%40workspace%3A.":
   version: 3.4.0
-  resolution: "modular-scripts@patch:modular-scripts@npm%3A3.4.0#.yarn/patches/modular-scripts-npm-3.4.0-8cdb747f13.patch::version=3.4.0&hash=7de322&locator=%40jpmorganchase%2Froot%40workspace%3A."
+  resolution: "modular-scripts@patch:modular-scripts@npm%3A3.4.0#.yarn/patches/modular-scripts-npm-3.4.0-8cdb747f13.patch::version=3.4.0&hash=96a37d&locator=%40jpmorganchase%2Froot%40workspace%3A."
   dependencies:
     "@babel/code-frame": 7.18.6
     "@modular-scripts/workspace-resolver": 1.2.0
@@ -19177,7 +19177,7 @@ __metadata:
     typescript: ^4.3.5
   bin:
     modular: dist-cjs/cli.js
-  checksum: 1c093cdb27b2462d398d29de0a7cb1a21874d96ec9ab1d0bf67f97fdef615a5e39d3dc18ae6bd7741fcac5afc90321f3f33c152b7082d6c8c16edff2fc6768fc
+  checksum: ea014bef7fd83aeda4361ec33dfa7cfef00779b164608fc40487949a605b22762884fd6e47ab169080d7daf87030e53f0cfe32ce7f832447ad4ca3220a34d9e7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Another half day wasted because of modular....

- Added additional modular patch and `tsconfig` change, so theme-editor-app could run and build
- Added a build job in GitHub action to ensure we don't break it again without noticing
- Updated `dependencies` in `package.json` to fix modular warning look like below 

> [modular] Package @jpmorganchase/uitk-theme imported in @jpmorganchase/theme-editor-app source but not found in package dependencies or hoisted dependencies - this will prevent you from successfully building, starting or moving esm-views and will cause an error in the next release of modular