### PR TITLE
Implemented Theme modes as data attributes

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -13,16 +13,16 @@ import { DocsContainer } from "@storybook/addon-docs";
 
 const densities = ["touch", "low", "medium", "high"];
 const DEFAULT_DENSITY = "medium";
-const DEFAULT_THEME = "light";
+const DEFAULT_MODE = "light";
 
 export const globalTypes: GlobalTypes = {
-  theme: {
-    name: "Theme",
+  mode: {
+    name: "Mode",
     description: "Set the color theme",
-    defaultValue: DEFAULT_THEME,
+    defaultValue: DEFAULT_MODE,
     toolbar: {
-      title: "Theme",
-      // show the theme name once selected in the toolbar
+      title: "Mode",
+      // show the mode name once selected in the toolbar
       dynamicTitle: true,
       items: [
         { value: "light", right: "⚪", title: "Light" },
@@ -114,7 +114,7 @@ export const parameters: Parameters = {
     }: ComponentProps<typeof DocsContainer> & { children?: ReactNode }) => (
       // @ts-ignore DocsContainer does not support React18 types
       <DocsContainer context={context}>
-        <ToolkitProvider theme={context.globals?.theme}>
+        <ToolkitProvider mode={context.globals?.mode}>
           {children}
         </ToolkitProvider>
       </DocsContainer>

--- a/cypress/support/commands.tsx
+++ b/cypress/support/commands.tsx
@@ -1,6 +1,6 @@
 import "@testing-library/cypress/add-commands";
 import { mount as cypressMount } from "cypress/react18";
-import type { MountReturn, MountOptions } from "cypress/react";
+import type { MountOptions, MountReturn } from "cypress/react";
 import "cypress-axe";
 import { Options } from "cypress-axe";
 import { PerformanceResult, PerformanceTester } from "./PerformanceTester";
@@ -104,7 +104,7 @@ Cypress.Commands.add("mount", function (children, options) {
   };
 
   return cypressMount(
-    <ToolkitProvider density={this.density} theme={this.theme}>
+    <ToolkitProvider density={this.density} mode={this.theme}>
       {children}
       <AnnouncementListener onAnnouncement={handleAnnouncement} />
     </ToolkitProvider>,

--- a/docs/components/AllRenderer.tsx
+++ b/docs/components/AllRenderer.tsx
@@ -30,7 +30,7 @@ export const AllRenderer = ({
           <Fragment key={i}>
             <ToolkitProvider
               density={d}
-              theme="light"
+              mode="light"
               key={"theme-light-" + d}
               applyClassesTo={"child"}
             >
@@ -39,7 +39,7 @@ export const AllRenderer = ({
             <ToolkitProvider
               applyClassesTo={"child"}
               density={d}
-              theme="dark"
+              mode="dark"
               key={"theme-dark-" + d}
             >
               <BackgroundBlock>{cloneElement(children)}</BackgroundBlock>

--- a/docs/components/QAContainer.tsx
+++ b/docs/components/QAContainer.tsx
@@ -47,14 +47,14 @@ const BackgroundBlock = ({
 const DensityValues = ["high", "medium", "low", "touch"] as const;
 
 const DensityBlock = ({
-  theme,
+  mode,
   children,
 }: DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> & {
-  theme: string;
+  mode: string;
 }) => (
-  <BackgroundBlock background={theme === "light" ? "white" : undefined}>
+  <BackgroundBlock background={mode === "light" ? "white" : undefined}>
     {DensityValues.map((d, i) => (
-      <ToolkitProvider theme={theme} density={d} key={i}>
+      <ToolkitProvider mode={mode} density={d} key={i}>
         <div className="background-item-wrapper">{children}</div>
       </ToolkitProvider>
     ))}
@@ -94,12 +94,12 @@ export const QAContainer = ({
       {transposeDensity ? (
         <>
           {Children.map(children, (child, i) => (
-            <DensityBlock key={i} theme="light">
+            <DensityBlock key={i} mode="light">
               {child}
             </DensityBlock>
           ))}
           {Children.map(children, (child, i) => (
-            <DensityBlock key={i} theme="dark">
+            <DensityBlock key={i} mode="dark">
               {child}
             </DensityBlock>
           ))}
@@ -107,10 +107,10 @@ export const QAContainer = ({
       ) : (
         DensityValues.map((d, i) => (
           <Fragment key={i}>
-            <ToolkitProvider theme="light" density={d}>
+            <ToolkitProvider mode="light" density={d}>
               <BackgroundBlock background="white">{children}</BackgroundBlock>
             </ToolkitProvider>
-            <ToolkitProvider theme="dark" density={d}>
+            <ToolkitProvider mode="dark" density={d}>
               <BackgroundBlock>{children}</BackgroundBlock>
             </ToolkitProvider>
           </Fragment>

--- a/docs/decorators/withTheme.tsx
+++ b/docs/decorators/withTheme.tsx
@@ -1,8 +1,7 @@
 import { DecoratorFn } from "@storybook/react";
-import { Panel, ToolkitProvider, useTheme } from "@jpmorganchase/uitk-core";
-import { useEffect } from "react";
+import { Panel, ToolkitProvider } from "@jpmorganchase/uitk-core";
 
-const THEMES = ["light", "dark"];
+const MODES = ["light", "dark"];
 
 // Modified from storybook background addon
 // https://github.com/storybookjs/storybook/blob/next/addons/backgrounds/src/helpers/index.ts
@@ -21,42 +20,11 @@ export const addBackgroundStyle = (selector: string, css: string) => {
   }
 };
 
-function SetBackground({ viewMode, id }: { viewMode: string; id: string }) {
-  const [theme] = useTheme();
-  const selectorId =
-    viewMode === "docs"
-      ? `addon-backgrounds-docs-${id}`
-      : `addon-backgrounds-color`;
-
-  const selector = viewMode === "docs" ? `.docs-story` : ".sb-show-main";
-
-  useEffect(() => {
-    const color = theme.getCharacteristicValue("text", "primary-foreground");
-    const background = theme.getCharacteristicValue(
-      "container",
-      "background-medium"
-    );
-
-    addBackgroundStyle(
-      selectorId,
-      `
-        ${selector} {
-          background: ${background || "unset"};
-          color: ${color || "unset"};
-          transition: background-color 0.3s;
-        }
-      `
-    );
-  }, [selectorId, selector, theme]);
-
-  return null;
-}
-
 export const withTheme: DecoratorFn = (StoryFn, context) => {
-  const { density, theme } = context.globals;
+  const { density, mode } = context.globals;
 
-  if (theme === "side-by-side" || theme === "stacked") {
-    const isStacked = theme === "stacked";
+  if (mode === "side-by-side" || mode === "stacked") {
+    const isStacked = mode === "stacked";
 
     return (
       <div
@@ -72,12 +40,12 @@ export const withTheme: DecoratorFn = (StoryFn, context) => {
           left: 0,
         }}
       >
-        {THEMES.map((theme) => (
+        {MODES.map((mode) => (
           <ToolkitProvider
             applyClassesTo={"child"}
             density={density}
-            theme={theme}
-            key={theme}
+            mode={mode}
+            key={mode}
           >
             <Panel>
               <StoryFn />
@@ -89,9 +57,11 @@ export const withTheme: DecoratorFn = (StoryFn, context) => {
   }
 
   return (
-    <ToolkitProvider density={density} theme={theme}>
-      <SetBackground viewMode={context.viewMode} id={context.id} />
-      <StoryFn />
+    <ToolkitProvider density={density} mode={mode}>
+      <Panel>
+        {/*<SetBackground viewMode={context.viewMode} id={context.id} />*/}
+        <StoryFn />
+      </Panel>
     </ToolkitProvider>
   );
 };

--- a/packages/ag-grid-theme/stories/dependencies/useAgGridHelpers.ts
+++ b/packages/ag-grid-theme/stories/dependencies/useAgGridHelpers.ts
@@ -1,7 +1,7 @@
 import { HTMLAttributes, useEffect, useMemo, useRef, useState } from "react";
 import { AgGridReactProps } from "ag-grid-react";
 import { ColumnApi, GridApi, GridReadyEvent } from "ag-grid-community";
-import { DEFAULT_THEME, useDensity, useTheme } from "@jpmorganchase/uitk-core";
+import { useDensity, useMode } from "@jpmorganchase/uitk-core";
 
 // Helps to set className, rowHeight and headerHeight depending on the current density
 export function useAgGridHelpers(): {
@@ -14,7 +14,7 @@ export function useAgGridHelpers(): {
   const apiRef = useRef<{ api: GridApi; columnApi: ColumnApi }>();
   const [isGridReady, setGridReady] = useState(false);
   const density = useDensity();
-  const themes = useTheme();
+  const mode = useMode();
 
   const [rowHeight, listItemHeight] = useMemo(() => {
     switch (density) {
@@ -31,10 +31,7 @@ export function useAgGridHelpers(): {
     }
   }, [density]);
 
-  const themeName =
-    themes && themes.length > 0 ? themes[0].name : DEFAULT_THEME.name;
-
-  const className = `ag-theme-uitk-${density}-${themeName}`;
+  const className = `ag-theme-uitk-${density}-${mode}`;
 
   const onGridReady = ({ api, columnApi }: GridReadyEvent) => {
     apiRef.current = { api, columnApi };

--- a/packages/core/src/__tests__/__e2e__/toolkit-provider/ToolkitProvider.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/toolkit-provider/ToolkitProvider.cy.tsx
@@ -1,8 +1,8 @@
 import {
-  characteristic,
-  useAriaAnnouncer,
   ToolkitProvider,
+  useAriaAnnouncer,
   useDensity,
+  useMode,
   useTheme,
 } from "@jpmorganchase/uitk-core";
 import { mount } from "cypress/react";
@@ -10,31 +10,23 @@ import { mount } from "cypress/react";
 const TestComponent = ({
   id = "test-1",
   className = "",
-  displayVariableValue,
 }: {
   id?: string;
   className?: string;
-  displayVariableValue?: [characteristic, string];
 }) => {
   const density = useDensity();
-  const themes = useTheme();
+  const theme = useTheme();
+  const mode = useMode();
   const { announce } = useAriaAnnouncer();
   const announcerPresent = typeof announce === "function";
-  const [theme] = themes;
-  let variableValue;
-
-  if (theme && displayVariableValue) {
-    const [characteristicName, variant] = displayVariableValue;
-    variableValue = theme.getCharacteristicValue(characteristicName, variant);
-  }
 
   return (
     <div
       id={id}
       className={className}
       data-density={density}
-      data-theme={theme?.id}
-      data-variable-value={variableValue}
+      data-theme={theme}
+      data-mode={mode}
       data-announcer={announcerPresent}
     />
   );
@@ -49,9 +41,9 @@ describe("Given a ToolkitProvider", () => {
         </ToolkitProvider>
       );
 
-      cy.get("div.uitk-theme")
+      cy.get("div.uitk-provider")
         .should("have.length", 2)
-        .and("have.class", "uitk-light")
+        .and("have.attr", "data-mode", "light")
         .and("have.class", "uitk-density-medium");
     });
     it("should apply correct default values for Density and Theme and add an AriaAnnouncer", () => {
@@ -63,7 +55,7 @@ describe("Given a ToolkitProvider", () => {
       cy.get("#test-1")
         .should("exist")
         .and("have.attr", "data-density", "medium")
-        .and("have.attr", "data-theme", "uitk-light")
+        .and("have.attr", "data-mode", "light")
         .and("have.attr", "data-announcer", "true");
       cy.get("[aria-live]").should("exist");
     });
@@ -72,14 +64,14 @@ describe("Given a ToolkitProvider", () => {
   describe("with props set", () => {
     it("should apply correct default value for Density and add an AriaAnnouncer", () => {
       cy.mount(
-        <ToolkitProvider theme="dark">
+        <ToolkitProvider mode="dark">
           <TestComponent />
         </ToolkitProvider>
       );
       cy.get("#test-1")
         .should("exist")
         .and("have.attr", "data-density", "medium")
-        .and("have.attr", "data-theme", "uitk-dark")
+        .and("have.attr", "data-mode", "dark")
         .and("have.attr", "data-announcer", "true");
     });
 
@@ -92,20 +84,20 @@ describe("Given a ToolkitProvider", () => {
       cy.get("#test-1")
         .should("exist")
         .and("have.attr", "data-density", "high")
-        .and("have.attr", "data-theme", "uitk-light")
+        .and("have.attr", "data-mode", "light")
         .and("have.attr", "data-announcer", "true");
     });
 
     it("should apply values specified in props", () => {
       cy.mount(
-        <ToolkitProvider density="high" theme="dark">
+        <ToolkitProvider density="high" mode="dark">
           <TestComponent />
         </ToolkitProvider>
       );
       cy.get("#test-1")
         .should("exist")
         .and("have.attr", "data-density", "high")
-        .and("have.attr", "data-theme", "uitk-dark")
+        .and("have.attr", "data-mode", "dark")
         .and("have.attr", "data-announcer", "true");
     });
   });
@@ -125,7 +117,7 @@ describe("Given a ToolkitProvider", () => {
 
     it("should inherit values not passed as props", () => {
       cy.mount(
-        <ToolkitProvider density="high" theme="dark">
+        <ToolkitProvider density="high" mode="dark">
           <TestComponent />
           <ToolkitProvider density="medium">
             <TestComponent id="test-2" />
@@ -136,13 +128,13 @@ describe("Given a ToolkitProvider", () => {
       cy.get("#test-1")
         .should("exist")
         .and("have.attr", "data-density", "high")
-        .and("have.attr", "data-theme", "uitk-dark")
+        .and("have.attr", "data-mode", "dark")
         .and("have.attr", "data-announcer", "true");
 
       cy.get("#test-2")
         .should("exist")
         .and("have.attr", "data-density", "medium")
-        .and("have.attr", "data-theme", "uitk-dark")
+        .and("have.attr", "data-mode", "dark")
         .and("have.attr", "data-announcer", "true");
     });
   });
@@ -150,33 +142,35 @@ describe("Given a ToolkitProvider", () => {
   describe("when child is passed to applyClassesTo", () => {
     it("should not create a div element", () => {
       cy.mount(
-        <ToolkitProvider density="high" theme="dark" applyClassesTo={"child"}>
+        <ToolkitProvider density="high" mode="dark" applyClassesTo={"child"}>
           <TestComponent />
         </ToolkitProvider>
       );
 
       // cy.mount adds a ToolkitProvider
-      cy.get("div.uitk-theme").should("have.length", 1);
+      cy.get("div.uitk-provider").should("have.length", 1);
 
       cy.get("#test-1")
         .should("exist")
-        .and("have.attr", "class", "uitk-dark uitk-density-high");
+        .and("have.attr", "data-mode", "dark")
+        .and("have.class", "uitk-theme")
+        .and("have.class", "uitk-density-high");
     });
   });
 
   describe("when root is passed to applyClassesTo", () => {
     it("should apply the given theme and density class names to the html element", () => {
       mount(
-        <ToolkitProvider density="high" theme="dark" applyClassesTo={"root"}>
+        <ToolkitProvider density="high" mode="dark" applyClassesTo={"root"}>
           <TestComponent />
         </ToolkitProvider>
       );
 
-      cy.get("uitk-theme").should("have.length", 0);
+      cy.get("uitk-provider").should("have.length", 0);
 
       cy.get("html")
         .should("exist")
-        .and("have.class", "uitk-dark")
+        .and("have.attr", "data-mode", "dark")
         .and("have.class", "uitk-density-high");
     });
   });

--- a/packages/core/src/toolkit-provider/ToolkitProvider.tsx
+++ b/packages/core/src/toolkit-provider/ToolkitProvider.tsx
@@ -9,35 +9,42 @@ import React, {
 } from "react";
 import { AriaAnnouncerProvider } from "../aria-announcer";
 import { Breakpoints, DEFAULT_BREAKPOINTS } from "../breakpoints";
-import { Density, getTheme, Theme } from "../theme";
+import { Density } from "../theme";
 import { ViewportProvider } from "../viewport";
 import { useIsomorphicLayoutEffect } from "../utils";
 
 export const DEFAULT_DENSITY = "medium";
 
-// TODO this forces anyone using ToolkitContext directly to deal with themes (as opposed to theme)
-// needs more thought
-export interface ToolkitContextProps {
-  density?: Density;
-  themes?: Theme[];
-  breakpoints: Breakpoints;
-}
+const DEFAULT_THEME_NAME = "uitk-theme";
 
-const DEFAULT_THEME_NAME = "light";
+const DEFAULT_MODE = "light";
+
+export interface ThemeContextProps {
+  theme: ThemeNameType;
+  mode: ThemeMode;
+}
 
 export const DensityContext = createContext<Density>(DEFAULT_DENSITY);
 
-export const ThemeContext = createContext<Theme[]>([]);
+export const ThemeContext = createContext<ThemeContextProps>({
+  theme: "",
+  mode: DEFAULT_MODE,
+});
 
 export const BreakpointContext =
   createContext<Breakpoints>(DEFAULT_BREAKPOINTS);
 
 const createThemedChildren = (
   children: ReactNode,
-  themeNames: string[],
+  themeName: string,
   density: Density,
+  mode: string,
   applyClassesTo?: TargetElement
 ) => {
+  const themeNames =
+    themeName === DEFAULT_THEME_NAME
+      ? [DEFAULT_THEME_NAME]
+      : [DEFAULT_THEME_NAME, themeName];
   if (applyClassesTo === "root") {
     return children;
   } else if (applyClassesTo === "child") {
@@ -48,6 +55,8 @@ const createThemedChildren = (
           ...themeNames,
           `uitk-density-${density}`
         ),
+        // @ts-ignore
+        "data-mode": mode,
       });
     } else {
       console.warn(
@@ -60,7 +69,12 @@ const createThemedChildren = (
   } else {
     return (
       <div
-        className={cx(`uitk-theme`, ...themeNames, `uitk-density-${density}`)}
+        className={cx(
+          `uitk-provider`,
+          ...themeNames,
+          `uitk-density-${density}`
+        )}
+        data-mode={mode}
       >
         {children}
       </div>
@@ -68,7 +82,9 @@ const createThemedChildren = (
   }
 };
 
-type ThemeNameType = string | Array<string>;
+type ThemeNameType = string;
+
+type ThemeMode = "light" | "dark";
 
 type TargetElement = "root" | "child";
 
@@ -76,6 +92,7 @@ type ToolkitProviderBaseProps = {
   applyClassesTo?: TargetElement;
   density?: Density;
   theme?: ThemeNameType;
+  mode?: ThemeMode;
   breakpoints?: Breakpoints;
 };
 
@@ -100,63 +117,52 @@ type ToolkitProviderProps =
   | ToolkitProviderThatInjectsThemeElement
   | ToolkitProviderThatClassesToRoot;
 
-const getThemeName = (
-  theme: ThemeNameType | undefined,
-  inheritedThemes: Theme[] | undefined
-): ThemeNameType => {
-  if (theme) {
-    return theme;
-  } else if (Array.isArray(inheritedThemes) && inheritedThemes.length > 0) {
-    return inheritedThemes.map((theme) => theme.name);
-  } else {
-    return DEFAULT_THEME_NAME;
-  }
-};
-
-const getThemeClassName = (themes: Theme[]): string[] =>
-  themes.map((theme) => `uitk-${theme.name}`);
-
 export function ToolkitProvider({
   applyClassesTo,
   children,
   density: densityProp,
   theme: themesProp,
+  mode: modeProp,
   breakpoints: breakpointsProp,
 }: ToolkitProviderProps) {
   const inheritedDensity = useContext(DensityContext);
-  const inheritedThemes = useContext(ThemeContext);
+  const inheritedThemes = useTheme();
+  const inheritedMode = useMode();
 
-  const isRoot =
-    inheritedThemes === undefined ||
-    (Array.isArray(inheritedThemes) && inheritedThemes.length === 0);
+  const isRoot = inheritedThemes === undefined || inheritedThemes === "";
   const density = densityProp ?? inheritedDensity ?? DEFAULT_DENSITY;
-  const themeName = getThemeName(themesProp, inheritedThemes);
-  const themNameAsString = themeName.toString();
-  const themes: Theme[] = useMemo(
-    () => getTheme(themeName),
-    // if an array is passed to theme inline, themes would be recalculated each time
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [themNameAsString]
-  );
+  const themeName =
+    themesProp ??
+    (inheritedThemes === "" ? DEFAULT_THEME_NAME : inheritedThemes);
+  const mode = modeProp ?? inheritedMode;
   const breakpoints = breakpointsProp ?? DEFAULT_BREAKPOINTS;
 
-  const themeClassnames = getThemeClassName(themes);
+  const themeContextValue = useMemo(
+    () => ({ theme: themeName, mode }),
+    [themeName, mode]
+  );
 
   const themedChildren = createThemedChildren(
     children,
-    themeClassnames,
+    themeName,
     density,
+    mode,
     applyClassesTo
   );
 
   useIsomorphicLayoutEffect(() => {
+    const themeNames =
+      themeName === DEFAULT_THEME_NAME
+        ? [DEFAULT_THEME_NAME]
+        : [DEFAULT_THEME_NAME, themeName];
     if (applyClassesTo === "root") {
       if (isRoot) {
         // add the styles we want to apply
         document.documentElement.classList.add(
-          ...themeClassnames,
+          ...themeNames,
           `uitk-density-${density}`
         );
+        document.documentElement.dataset.mode = mode;
       } else {
         console.warn(
           "\nToolkitProvider can only apply CSS classes to the root if it is the root level ToolkitProvider."
@@ -167,16 +173,17 @@ export function ToolkitProvider({
       if (applyClassesTo === "root") {
         // When unmounting/remounting, remove the applied styles from the root
         document.documentElement.classList.remove(
-          ...themeClassnames,
+          ...themeNames,
           `uitk-density-${density}`
         );
+        document.documentElement.dataset.mode = undefined;
       }
     };
-  }, [applyClassesTo, density, isRoot, themeClassnames]);
+  }, [applyClassesTo, density, isRoot, mode, themeName]);
 
   const toolkitProvider = (
     <DensityContext.Provider value={density}>
-      <ThemeContext.Provider value={themes}>
+      <ThemeContext.Provider value={themeContextValue}>
         <BreakpointContext.Provider value={breakpoints}>
           <ViewportProvider>{themedChildren}</ViewportProvider>
         </BreakpointContext.Provider>
@@ -191,12 +198,16 @@ export function ToolkitProvider({
   }
 }
 
-export const useTheme = (): Theme[] => {
-  return useContext(ThemeContext);
+export const useTheme = (): ThemeNameType => {
+  return useContext(ThemeContext).theme;
+};
+
+export const useMode = (): ThemeMode => {
+  return useContext(ThemeContext).mode;
 };
 
 /**
- * `useDensity` merges density value from 'DensityContext` with the one from component's props.
+ * `useDensity` merges density value from `DensityContext` with the one from component's props.
  */
 export function useDensity(density?: Density): Density {
   const densityFromContext = useContext(DensityContext);

--- a/packages/core/stories/card.stories.tsx
+++ b/packages/core/stories/card.stories.tsx
@@ -104,10 +104,10 @@ export const InteractableDisabled: ComponentStory<typeof Card> = () => (
 
 export const All: ComponentStory<typeof Card> = () => (
   <div style={{ marginTop: -200 }}>
-    <ToolkitProvider theme="light">
+    <ToolkitProvider mode="light">
       <Examples />
     </ToolkitProvider>
-    <ToolkitProvider theme="dark">
+    <ToolkitProvider mode="dark">
       <Examples />
     </ToolkitProvider>
   </div>

--- a/packages/core/stories/form-field.stories.tsx
+++ b/packages/core/stories/form-field.stories.tsx
@@ -242,8 +242,8 @@ const renderAllDensities = (props?: Partial<FormFieldProps>) => (
 export const AllDensitiesTwoThemes: ComponentStory<typeof FormField> = () => {
   return (
     <div style={{ display: "flex" }}>
-      <ToolkitProvider theme="light">{renderAllDensities()}</ToolkitProvider>
-      <ToolkitProvider theme="dark">{renderAllDensities()}</ToolkitProvider>
+      <ToolkitProvider mode="light">{renderAllDensities()}</ToolkitProvider>
+      <ToolkitProvider mode="dark">{renderAllDensities()}</ToolkitProvider>
     </div>
   );
 };

--- a/packages/core/stories/radio-button.stories.tsx
+++ b/packages/core/stories/radio-button.stories.tsx
@@ -99,10 +99,10 @@ const StoryScroller = (props: { children?: ReactNode }) => (
 
 export const All: Story = () => (
   <StoryScroller>
-    <ToolkitProvider theme="light">
+    <ToolkitProvider mode="light">
       <DensityExample name="light" />
     </ToolkitProvider>
-    <ToolkitProvider theme="dark">
+    <ToolkitProvider mode="dark">
       <DensityExample name="dark" />
     </ToolkitProvider>
   </StoryScroller>
@@ -218,8 +218,8 @@ const FormFieldRadios = ({
   </div>
 );
 
-const VariantExample = ({ name, theme }: { name: string; theme: string }) => (
-  <ToolkitProvider theme={theme}>
+const VariantExample = ({ name, mode }: { name: string; mode: string }) => (
+  <ToolkitProvider mode={mode}>
     <Panel style={{ height: "unset" }}>
       <ColumnLayoutContainer>
         <ColumnLayoutItem>
@@ -250,8 +250,8 @@ const VariantExample = ({ name, theme }: { name: string; theme: string }) => (
 
 export const FormFieldVariants: Story = () => (
   <StoryScroller>
-    <VariantExample name="fx1" theme="light" />
-    <VariantExample name="fx2" theme="dark" />
+    <VariantExample name="fx1" mode="light" />
+    <VariantExample name="fx2" mode="dark" />
   </StoryScroller>
 );
 
@@ -280,8 +280,8 @@ const ExampleRow = ({ children, name }: ExampleRowProps) => {
   );
 };
 
-const GroupFormFieldExamples = ({ theme }: { theme: string }) => (
-  <ToolkitProvider theme={theme}>
+const GroupFormFieldExamples = ({ mode }: { mode: string }) => (
+  <ToolkitProvider mode={mode}>
     <>
       <ExampleRow name="Basic">
         <FormField
@@ -383,8 +383,8 @@ const GroupFormFieldExamples = ({ theme }: { theme: string }) => (
 
 export const GroupFormFieldRow: Story = () => (
   <StoryScroller>
-    <GroupFormFieldExamples theme="light" />
-    <GroupFormFieldExamples theme="dark" />
+    <GroupFormFieldExamples mode="light" />
+    <GroupFormFieldExamples mode="dark" />
   </StoryScroller>
 );
 
@@ -511,10 +511,10 @@ const GroupFormFieldVerticalExamples = () => (
 
 export const GroupFormFieldVertical: Story = () => (
   <StoryScroller>
-    <ToolkitProvider theme="light">
+    <ToolkitProvider mode="light">
       <GroupFormFieldVerticalExamples />
     </ToolkitProvider>
-    <ToolkitProvider theme="dark">
+    <ToolkitProvider mode="dark">
       <GroupFormFieldVerticalExamples />
     </ToolkitProvider>
   </StoryScroller>

--- a/packages/core/stories/toolkit-provider.doc.stories.mdx
+++ b/packages/core/stories/toolkit-provider.doc.stories.mdx
@@ -1,10 +1,5 @@
-import { Meta, Story, Canvas } from "@storybook/addon-docs";
-import {
-  Button,
-  Card,
-  ToolkitProvider,
-  Portal,
-} from "@jpmorganchase/uitk-core";
+import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Card, ToolkitProvider } from "@jpmorganchase/uitk-core";
 
 import { NestedProviders } from "./toolkit-provider.stories";
 
@@ -29,7 +24,7 @@ light theme and high density.
 
 <Canvas>
   <Story name="Simple ToolkitProvider - Touch Density">
-    <ToolkitProvider density="high" theme="light">
+    <ToolkitProvider density="high" mode="light">
       <Card>
         <div>
           <h1>This is Card</h1>
@@ -53,7 +48,7 @@ By default, the `ToolkitProvider` wraps nested content with a `div` element to w
 Given this JSX
 
 ```jsx
-<ToolkitProvider theme="light" density="medium">
+<ToolkitProvider mode="light" density="medium">
   <Card>...</Card>
 </ToolkitProvider>
 ```
@@ -61,7 +56,7 @@ Given this JSX
 then we would see the following HTML.
 
 ```html
-<div class="utik-theme uitk-theme-light uitk-density-medium">
+<div class="utik-theme uitk-density-medium" data-mode="light">
   <div class="uitkCard">...</div>
 </div>
 ```
@@ -76,7 +71,7 @@ There is (currently) one limitation to this pattern, you must use a single child
 for TypeScript users, via the typings.This would look as follows.
 
 ```jsx
-<ToolkitProvider theme="light" density="dark" applyClassesTo={"child"}>
+<ToolkitProvider mode="light" density="medium" applyClassesTo={"child"}>
   <Card>...</Card>
 </ToolkitProvider>
 ```
@@ -84,7 +79,7 @@ for TypeScript users, via the typings.This would look as follows.
 Then we would see the following HTML.
 
 ```html
-<div class="uitkCard uitk-light uitk-density-medium">...</div>
+<div class="uitkCard uitk-theme uitk-density-medium" data-mode="dark">...</div>
 ```
 
 The `ToolkitProvider` can also be configured to add the required CSS classes to the root HTML element. This would allow you to apply styles
@@ -94,7 +89,7 @@ or to apply styling to the whole background of the page.
 This would look as follows.
 
 ```jsx
-<ToolkitProvider theme="light" density="dark" applyClassesTo={"root"}>
+<ToolkitProvider mode="light" density="dark" applyClassesTo={"root"}>
   <Card>...</Card>
 </ToolkitProvider>
 ```
@@ -179,7 +174,7 @@ function MyComponent() {
 
 ## useTheme
 
-You can use the `useTheme` hook to access the value which indicates which themes are currently active. The `useTheme` hook returns the array value of the currently set themes in scope. The available themes by default are "uitk-light" and "uitk-dark". You can optionally override these values by providing an array of theme names to `ToolkitProvider` via the `themes` prop.
+You can use the `useTheme` hook to access the value which indicates which theme is currently active. The `useTheme` hook returns the string value of the currently set theme in scope. You can optionally override these values by providing an array of theme names to `ToolkitProvider` via the `themes` prop.
 
 ```tsx
 import { useTheme } from "@jpmorganchase/uitk-core";
@@ -189,6 +184,19 @@ function MyComponent() {
   return (
     <div>{currentTheme === "uitk-light" ? "Light Theme" : "Dark Theme"}</div>
   );
+}
+```
+
+## useMode
+
+You can use the `useMode` hook to access the value which indicates which theme mode is currently active. The `useMode` hook returns the string value of the currently set mode. The available themes by default are "light" and "dark". You can optionally override these values by providing a mode names to `ToolkitProvider` via the `mode` prop.
+
+```tsx
+import { useMode } from "@jpmorganchase/uitk-core";
+
+function MyComponent() {
+  const [currentMode] = useMode();
+  return <div>{currentMode === "light" ? "Light Mode" : "Dark Mode"}</div>;
 }
 ```
 

--- a/packages/core/stories/toolkit-provider.stories.tsx
+++ b/packages/core/stories/toolkit-provider.stories.tsx
@@ -25,7 +25,7 @@ const DARK = 1;
 const HIGH = 0;
 const NO_DENSITY = 4;
 
-const THEMES = ["light", "dark"];
+const MODES = ["light", "dark"];
 const DENSITIES: Density[] = ["high", "medium", "low", "touch"];
 
 export const ToggleTheme = () => {
@@ -39,7 +39,7 @@ export const ToggleTheme = () => {
   };
 
   return (
-    <ToolkitProvider theme={THEMES[theme]}>
+    <ToolkitProvider mode={MODES[theme]}>
       <Card>
         <div>
           <h1>This Card is wrapped with a ToolkitProvider</h1>
@@ -47,7 +47,7 @@ export const ToggleTheme = () => {
             <ToggleButton aria-label="light theme">Light</ToggleButton>
             <ToggleButton aria-label="dark theme">Dark</ToggleButton>
           </ToggleButtonGroup>
-          <p>{`This Card is wrapped with a ToolkitProvider, theme is ${THEMES[theme]}`}</p>
+          <p>{`This Card is wrapped with a ToolkitProvider, mode is ${MODES[theme]}`}</p>
 
           <Checkbox label="Example Choice 1" />
           <Checkbox defaultChecked label="Example Choice 2" />
@@ -106,10 +106,7 @@ export const NestedProviders = () => {
   };
 
   return (
-    <ToolkitProvider
-      density={DENSITIES[outerDensity]}
-      theme={THEMES[outerTheme]}
-    >
+    <ToolkitProvider density={DENSITIES[outerDensity]} mode={MODES[outerTheme]}>
       <Card>
         <div>
           <h1>This Card is wrapped with a ToolkitProvider</h1>
@@ -138,7 +135,7 @@ export const NestedProviders = () => {
         </div>
         <br />
         <ToolkitProvider
-          theme={THEMES[innerTheme]}
+          mode={MODES[innerTheme]}
           density={DENSITIES[innerDensity]}
         >
           <Card>

--- a/packages/grid/src/Grid.css
+++ b/packages/grid/src/Grid.css
@@ -31,7 +31,7 @@
 }
 
 /* These ideally should be taken from characteristics */
-.uitk-light {
+.uitk-theme[data-mode^="light"] {
   --grid-background-primary-default: var(--uitk-color-white);
   --grid-background-secondary-default: var(--uitk-color-grey-20);
   --grid-zebraColor-default: var(--uitk-color-grey-20);
@@ -63,7 +63,7 @@
   --grid-rowSeparator-color-divided-default: rgba(0, 0, 0, 0.2);
 }
 
-.uitk-dark {
+.uitk-theme[data-mode^="dark"] {
   --grid-background-primary-default: var(--uitk-color-grey-800);
   --grid-background-secondary-default: #2f3136;
   --grid-zebraColor-default: rgba(255, 255, 255, 0.05);

--- a/packages/lab/src/color-chooser/DictTabs.css
+++ b/packages/lab/src/color-chooser/DictTabs.css
@@ -1,5 +1,5 @@
 /* TODO: get rid of this once Tabs is compatible with dark theme */
-.uitk-light .uitkColorChooserDictTabs-text {
+.uitk-theme[data-mode^="light"] .uitkColorChooserDictTabs-text {
   background-color: transparent;
   color: var(--uitk-text-primary-foreground) !important;
 }

--- a/packages/lab/src/color-chooser/Swatch.css
+++ b/packages/lab/src/color-chooser/Swatch.css
@@ -30,7 +30,7 @@
 }
 
 .uitkColorChooserSwatch-swatch,
-.uitk-light .uitkColorChooserSwatch-greySwatch {
+.uitk-theme[data-mode^="light"] .uitkColorChooserSwatch-greySwatch {
   width: var(--colorChooser-swatch-size-unit);
   height: var(--colorChooser-swatch-size-unit);
 }
@@ -41,27 +41,27 @@
   cursor: pointer;
 }
 
-.uitk-light .uitkColorChooserSwatch-whiteSwatch {
+.uitk-theme[data-mode^="light"] .uitkColorChooserSwatch-whiteSwatch {
   border: var(--uitk-container-borderWidth) var(--uitk-container-borderColor-style) var(--uitk-container-borderColor-medium);
 }
 
-.uitk-light .uitkColorChooserSwatch-whiteSwatch,
-.uitk-dark .uitkColorChooserSwatch-greySwatch {
+.uitk-theme[data-mode^="light"] .uitkColorChooserSwatch-whiteSwatch,
+.uitk-theme[data-mode^="dark"] .uitkColorChooserSwatch-greySwatch {
   width: calc(var(--colorChooser-swatch-size-unit) - 2);
   height: calc(var(--colorChooser-swatch-size-unit) - 2);
 }
 
-.uitk-dark .uitkColorChooserSwatch-whiteSwatch,
+.uitk-theme[data-mode^="dark"] .uitkColorChooserSwatch-whiteSwatch,
 .uitkColorChooserSwatch-greySwatch {
   border: 0px;
 }
 
-.uitk-dark .uitkColorChooserSwatch-whiteSwatch {
+.uitk-theme[data-mode^="dark"] .uitkColorChooserSwatch-whiteSwatch {
   width: calc(var(--colorChooser-swatch-size-unit) - 2);
   height: calc(var(--colorChooser-swatch-size-unit) - 2);
 }
 
-.uitk-dark .uitkColorChooserSwatch-greySwatch {
+.uitk-theme[data-mode^="dark"] .uitkColorChooserSwatch-greySwatch {
   border: var(--uitk-container-borderWidth) var(--uitk-container-borderColor-style) var(--uitk-container-borderColor-medium);
 }
 

--- a/packages/lab/stories/banner.qa.stories.tsx
+++ b/packages/lab/stories/banner.qa.stories.tsx
@@ -37,22 +37,22 @@ const SuccessBanner = () => <BasicBannerExample status={"success"} />;
 
 export const ExamplesGrid: Story = () => (
   <StackLayout gap={2}>
-    <ToolkitProvider applyClassesTo={"child"} density={"high"} theme={"light"}>
+    <ToolkitProvider applyClassesTo={"child"} density={"high"} mode={"light"}>
       <div className="uitkBannerContainerExample">
         <InfoBanner />
       </div>
     </ToolkitProvider>
-    <ToolkitProvider applyClassesTo={"child"} density={"medium"} theme={"dark"}>
+    <ToolkitProvider applyClassesTo={"child"} density={"medium"} mode={"dark"}>
       <div className="uitkBannerContainerExample">
         <ErrorBanner />
       </div>
     </ToolkitProvider>
-    <ToolkitProvider applyClassesTo={"child"} density={"low"} theme={"light"}>
+    <ToolkitProvider applyClassesTo={"child"} density={"low"} mode={"light"}>
       <div className="uitkBannerContainerExample">
         <WarningBanner />
       </div>
     </ToolkitProvider>
-    <ToolkitProvider applyClassesTo={"child"} density={"touch"} theme={"dark"}>
+    <ToolkitProvider applyClassesTo={"child"} density={"touch"} mode={"dark"}>
       <div className="uitkBannerContainerExample">
         <SuccessBanner />
       </div>

--- a/packages/lab/stories/contact-details/contact-details.stories.css
+++ b/packages/lab/stories/contact-details/contact-details.stories.css
@@ -1,8 +1,8 @@
-.uitk-light .withoutAvatar {
+.uitk-theme[data-mode^="light"] .withoutAvatar {
   --heading-color: var(--uitk-color-grey-700);
 }
 
-.uitk-dark .withoutAvatar {
+.uitk-theme[data-mode^="dark"] .withoutAvatar {
   --heading-color: var(--uitk-color-grey-10);
 }
 
@@ -104,10 +104,10 @@
   margin-bottom: 16px;
 }
 
-.uitk-dark .allVariants-withBackground {
+.uitk-theme[data-mode^="dark"] .allVariants-withBackground {
   background: var(--uitk-color-blue-900);
 }
 
-.uitk-light .allVariants-withBackground {
+.uitk-theme[data-mode^="light"] .allVariants-withBackground {
   background: var(--uitk-color-blue-10);
 }

--- a/packages/lab/stories/dialog.qa.stories.tsx
+++ b/packages/lab/stories/dialog.qa.stories.tsx
@@ -63,20 +63,20 @@ const SuccessDialog = () => <BasicDialogExample status={"success"} />;
 
 export const ExamplesGrid: Story = () => (
   <div className={"examples-container"}>
-    <ToolkitProvider applyClassesTo={"child"} density={"high"} theme={"light"}>
+    <ToolkitProvider applyClassesTo={"child"} density={"high"} mode={"light"}>
       <BasicDialog />
     </ToolkitProvider>
-    <ToolkitProvider applyClassesTo={"child"} density={"medium"} theme={"dark"}>
+    <ToolkitProvider applyClassesTo={"child"} density={"medium"} mode={"dark"}>
       <div>
         <ErrorDialog />
       </div>
     </ToolkitProvider>
-    <ToolkitProvider applyClassesTo={"child"} density={"low"} theme={"light"}>
+    <ToolkitProvider applyClassesTo={"child"} density={"low"} mode={"light"}>
       <div>
         <WarningDialog />
       </div>
     </ToolkitProvider>
-    <ToolkitProvider applyClassesTo={"child"} density={"touch"} theme={"dark"}>
+    <ToolkitProvider applyClassesTo={"child"} density={"touch"} mode={"dark"}>
       <div>
         <SuccessDialog />
       </div>

--- a/packages/lab/stories/progress.stories.tsx
+++ b/packages/lab/stories/progress.stories.tsx
@@ -79,10 +79,10 @@ export const CircularAll: ComponentStory<typeof CircularProgress> = () => (
       right: 0,
     }}
   >
-    <ToolkitProvider theme="light">
+    <ToolkitProvider mode="light">
       <CircularExamples />
     </ToolkitProvider>
-    <ToolkitProvider theme="dark">
+    <ToolkitProvider mode="dark">
       <CircularExamples />
     </ToolkitProvider>
   </div>
@@ -216,10 +216,10 @@ export const LinearAll: ComponentStory<typeof LinearProgress> = () => (
       right: 0,
     }}
   >
-    <ToolkitProvider theme="light">
+    <ToolkitProvider mode="light">
       <LinearExamples />
     </ToolkitProvider>
-    <ToolkitProvider theme="dark">
+    <ToolkitProvider mode="dark">
       <LinearExamples />
     </ToolkitProvider>
   </div>

--- a/packages/lab/stories/stepper-input.stories.tsx
+++ b/packages/lab/stories/stepper-input.stories.tsx
@@ -89,10 +89,10 @@ export const Alignment: Story = () => (
 
 export const All: Story = () => (
   <div style={{ marginTop: -200 }}>
-    <ToolkitProvider theme="light">
+    <ToolkitProvider mode="light">
       <Examples />
     </ToolkitProvider>
-    <ToolkitProvider theme="dark">
+    <ToolkitProvider mode="dark">
       <Examples />
     </ToolkitProvider>
   </div>

--- a/packages/theme/css/characteristics/accent.css
+++ b/packages/theme/css/characteristics/accent.css
@@ -1,5 +1,4 @@
-.uitk-light,
-.uitk-dark {
+.uitk-theme {
   --uitk-accent-background: var(--uitk-palette-accent-background);
   --uitk-accent-borderColor: var(--uitk-palette-accent-border);
   --uitk-accent-foreground: var(--uitk-palette-accent-foreground);

--- a/packages/theme/css/characteristics/actionable.css
+++ b/packages/theme/css/characteristics/actionable.css
@@ -1,5 +1,4 @@
-.uitk-light,
-.uitk-dark {
+.uitk-theme {
   --uitk-actionable-cursor-hover: pointer;
   --uitk-actionable-cursor-active: pointer;
   --uitk-actionable-cursor-disabled: not-allowed;

--- a/packages/theme/css/characteristics/container.css
+++ b/packages/theme/css/characteristics/container.css
@@ -1,5 +1,4 @@
-.uitk-light,
-.uitk-dark {
+.uitk-theme {
   --uitk-container-borderStyle: solid;
   --uitk-container-borderWidth: 1px;
 

--- a/packages/theme/css/characteristics/differential.css
+++ b/packages/theme/css/characteristics/differential.css
@@ -1,5 +1,4 @@
-.uitk-light,
-.uitk-dark {
+.uitk-theme {
   --uitk-differential-positive-foreground: var(--uitk-palette-positive-foreground);
   --uitk-differential-negative-foreground: var(--uitk-palette-negative-foreground);
 }

--- a/packages/theme/css/characteristics/draggable.css
+++ b/packages/theme/css/characteristics/draggable.css
@@ -1,5 +1,4 @@
-.uitk-light,
-.uitk-dark {
+.uitk-theme {
   --uitk-draggable-horizontal-cursor-hover: row-resize;
   --uitk-draggable-horizontal-cursor-active: row-resize;
 

--- a/packages/theme/css/characteristics/droptarget.css
+++ b/packages/theme/css/characteristics/droptarget.css
@@ -1,5 +1,4 @@
-.uitk-light,
-.uitk-dark {
+.uitk-theme {
   --uitk-dropTarget-borderStyle: dashed;
   --uitk-dropTarget-borderStyle-hover: dashed;
   --uitk-dropTarget-borderStyle-disabled: dashed;

--- a/packages/theme/css/characteristics/editable.css
+++ b/packages/theme/css/characteristics/editable.css
@@ -1,5 +1,4 @@
-.uitk-dark,
-.uitk-light {
+.uitk-theme {
   --uitk-editable-cursor-hover: text;
   --uitk-editable-cursor-active: text;
   --uitk-editable-cursor-disabled: not-allowed;

--- a/packages/theme/css/characteristics/focused.css
+++ b/packages/theme/css/characteristics/focused.css
@@ -1,5 +1,4 @@
-.uitk-light,
-.uitk-dark {
+.uitk-theme {
   --uitk-focused-outlineColor: var(--uitk-palette-info-border);
   --uitk-focused-outlineStyle: dotted;
   --uitk-focused-outlineWidth: 2px;

--- a/packages/theme/css/characteristics/measured.css
+++ b/packages/theme/css/characteristics/measured.css
@@ -1,5 +1,4 @@
-.uitk-light,
-.uitk-dark {
+.uitk-theme {
   --uitk-measured-borderStyle: solid;
   --uitk-measured-borderStyle-active: solid;
   --uitk-measured-borderStyle-complete: solid;

--- a/packages/theme/css/characteristics/navigable.css
+++ b/packages/theme/css/characteristics/navigable.css
@@ -1,5 +1,4 @@
-.uitk-light,
-.uitk-dark {
+.uitk-theme {
   --uitk-navigable-cursor-active: pointer;
   --uitk-navigable-cursor-hover: pointer;
   --uitk-navigable-cursor-disabled: not-allowed;

--- a/packages/theme/css/characteristics/overlayable.css
+++ b/packages/theme/css/characteristics/overlayable.css
@@ -1,5 +1,4 @@
-.uitk-light,
-.uitk-dark {
+.uitk-theme {
   --uitk-overlayable-shadow-scroll: var(--uitk-shadow-1);
   --uitk-overlayable-shadow-borderRegion: var(--uitk-shadow-2);
   --uitk-overlayable-shadow: var(--uitk-shadow-2);

--- a/packages/theme/css/characteristics/ratable.css
+++ b/packages/theme/css/characteristics/ratable.css
@@ -1,5 +1,4 @@
-.uitk-light,
-.uitk-dark {
+.uitk-theme {
   --uitk-ratable-cursor-hover: pointer;
   --uitk-ratable-cursor-active: pointer;
   --uitk-ratable-cursor-undo: pointer;

--- a/packages/theme/css/characteristics/selectable.css
+++ b/packages/theme/css/characteristics/selectable.css
@@ -1,5 +1,4 @@
-.uitk-light,
-.uitk-dark {
+.uitk-theme {
   --uitk-selectable-cursor-hover: pointer;
   --uitk-selectable-cursor-selected: pointer;
   --uitk-selectable-cursor-blurSelected: pointer;

--- a/packages/theme/css/characteristics/separable.css
+++ b/packages/theme/css/characteristics/separable.css
@@ -1,5 +1,4 @@
-.uitk-light,
-.uitk-dark {
+.uitk-theme {
   --uitk-separable-borderStyle: solid;
   --uitk-separable-borderWidth: 1px;
 

--- a/packages/theme/css/characteristics/status.css
+++ b/packages/theme/css/characteristics/status.css
@@ -1,5 +1,5 @@
-.uitk-dark,
-.uitk-light {
+.uitk-theme[data-mode^="dark"],
+.uitk-theme[data-mode^="light"] {
   --uitk-status-info-foreground: var(--uitk-palette-info-icon);
   --uitk-status-success-foreground: var(--uitk-palette-success-icon);
   --uitk-status-warning-foreground: var(--uitk-palette-warning-icon);

--- a/packages/theme/css/characteristics/taggable.css
+++ b/packages/theme/css/characteristics/taggable.css
@@ -1,5 +1,4 @@
-.uitk-light,
-.uitk-dark {
+.uitk-theme {
   --uitk-taggable-cursor-hover: pointer;
   --uitk-taggable-cursor-active: pointer;
   --uitk-taggable-cursor-disabled: not-allowed;

--- a/packages/theme/css/characteristics/text.css
+++ b/packages/theme/css/characteristics/text.css
@@ -1,5 +1,4 @@
-.uitk-light,
-.uitk-dark {
+.uitk-theme {
   /* Body text (default), tokens that don't vary by density */
   --uitk-text-base-lineHeight: var(--uitk-typography-lineHeight);
   --uitk-text-fontFamily: var(--uitk-typography-fontFamily);

--- a/packages/theme/css/foundations/color.css
+++ b/packages/theme/css/foundations/color.css
@@ -1,11 +1,9 @@
-.uitk-light,
-.uitk-dark {
+.uitk-theme {
   --uitk-color-white: rgb(255, 255, 255);
   --uitk-color-black: rgb(0, 0, 0);
 }
 
-.uitk-light,
-.uitk-dark {
+.uitk-theme {
   /* Color palette will stay the same no matter of theming */
   --uitk-color-white: rgb(255, 255, 255);
   --uitk-color-black: rgb(0, 0, 0);

--- a/packages/theme/css/foundations/delay.css
+++ b/packages/theme/css/foundations/delay.css
@@ -1,5 +1,4 @@
-.uitk-light,
-.uitk-dark {
+.uitk-theme {
   --uitk-delay-instant: 100;
   --uitk-delay-perceptible: 300;
   --uitk-delay-notable: 1000;

--- a/packages/theme/css/foundations/fade.css
+++ b/packages/theme/css/foundations/fade.css
@@ -1,5 +1,4 @@
-.uitk-light,
-.uitk-dark {
+.uitk-theme {
   --uitk-color-blue-30-fade-99: rgba(164, 213, 244, 0.99); /* see Editable characteristic for explanation of this value */
   --uitk-color-blue-700-fade-99: rgba(0, 71, 123, 0.99); /* see Editable characteristic for explanation of this value */
 

--- a/packages/theme/css/foundations/opacity.css
+++ b/packages/theme/css/foundations/opacity.css
@@ -1,5 +1,4 @@
-.uitk-light,
-.uitk-dark {
+.uitk-theme {
   --uitk-opacity-1: 0.2;
   --uitk-opacity-2: 0.4;
   --uitk-opacity-3: 0.7;

--- a/packages/theme/css/foundations/palette.css
+++ b/packages/theme/css/foundations/palette.css
@@ -1,6 +1,5 @@
 /* Opacities */
-.uitk-light,
-.uitk-dark {
+.uitk-theme {
   --uitk-palette-opacity-background: var(--uitk-opacity-3);
   --uitk-palette-opacity-border: var(--uitk-opacity-2);
   --uitk-palette-opacity-border-readonly: var(--uitk-opacity-1);
@@ -10,15 +9,15 @@
   --uitk-palette-opacity-stroke: var(--uitk-opacity-2);
 }
 
-.uitk-light {
+.uitk-theme[data-mode^="light"] {
   --uitk-palette-opacity-scrim-medium: var(--uitk-opacity-4);
 }
 
-.uitk-dark {
+.uitk-theme[data-mode^="dark"] {
   --uitk-palette-opacity-scrim-medium: var(--uitk-opacity-3);
 }
 
-.uitk-light {
+.uitk-theme[data-mode^="light"] {
   /* Accent */
   --uitk-palette-accent-background: var(--uitk-color-blue-500);
   --uitk-palette-accent-border: var(--uitk-color-blue-500);
@@ -160,7 +159,7 @@
   --uitk-palette-rate-border-undo: var(--uitk-color-orange-600);
 }
 
-.uitk-dark {
+.uitk-theme[data-mode^="dark"] {
   /* Accent */
   --uitk-palette-accent-background: var(--uitk-color-blue-500);
   --uitk-palette-accent-border: var(--uitk-color-blue-500);

--- a/packages/theme/css/foundations/shadow.css
+++ b/packages/theme/css/foundations/shadow.css
@@ -1,4 +1,4 @@
-.uitk-light {
+.uitk-theme[data-mode^="light"] {
   --uitk-shadow-0: none;
   --uitk-shadow-1: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
   --uitk-shadow-2: 0 2px 4px 0 rgba(0, 0, 0, 0.1);
@@ -7,7 +7,7 @@
   --uitk-shadow-5: 0 12px 40px 5px rgba(0, 0, 0, 0.3);
 }
 
-.uitk-dark {
+.uitk-theme[data-mode^="dark"] {
   --uitk-shadow-0: none;
   --uitk-shadow-1: 0 1px 3px 0 rgba(0, 0, 0, 0.5);
   --uitk-shadow-2: 0 2px 4px 0 rgba(0, 0, 0, 0.5);

--- a/packages/theme/css/foundations/typography.css
+++ b/packages/theme/css/foundations/typography.css
@@ -16,8 +16,7 @@
 }
 
 /* TODO add uitk top-level identifier */
-.uitk-light,
-.uitk-dark {
+.uitk-theme {
   font-family: var(--uitk-typography-fontFamily);
   font-size: 14px;
 }

--- a/packages/theme/css/global.css
+++ b/packages/theme/css/global.css
@@ -17,15 +17,15 @@ body {
   font-family: "uitk-sans";
 }
 
-.uitk-theme {
+.uitk-provider {
   display: contents;
 }
 
-.uitk-light {
+.uitk-theme[data-mode^="light"] {
   color-scheme: light;
 }
 
-.uitk-dark {
+.uitk-theme[mode="dark"] {
   color-scheme: dark;
 }
 

--- a/packages/theme/stories/foundations/foundations.stories.mdx
+++ b/packages/theme/stories/foundations/foundations.stories.mdx
@@ -23,8 +23,7 @@ Foundation design tokens should generally be in the format `--uitk-<foundation n
 Wrap the foundation you wish to use inside a `var()` function. Most commonly, foundations are used when referenced by characteristics, for example:
 
 ```css
-.uitk-light,
-.uitk-dark {
+.uitk-theme {
   --uitk-actionable-primary-fontWeight: var(--uitk-typography-fontWeight-bold);
 }
 ```

--- a/packages/theme/stories/introduction.stories.mdx
+++ b/packages/theme/stories/introduction.stories.mdx
@@ -1,13 +1,6 @@
-import { Meta, Story, Canvas } from "@storybook/addon-docs";
-import { DocGrid } from "docs/components/DocGrid";
-import { ColorBlock } from "docs/components/ColorBlock";
 import {
-  LineBlock,
-  LineBlockCell,
-  LineBlockCode,
-  LineBlockDotted,
-} from "docs/components/LineBlock";
-import { CornerBlock } from "docs/components/CornerBlock";
+  Meta
+} from "@storybook/addon-docs";
 
 <Meta title="Documentation/Styles and Theming/Introduction" />
 
@@ -145,12 +138,12 @@ Consider the example given above:
 In this case, the scope is `:root`. This is equivalent to `html` so variables declared in this way are global. They can be referenced in any CSS that is applied to the page. We constrain the scope of a variable using a CSS selector, exactly as we declare regular CSS rules:
 
 ```css
-.uitk-light {
+.uitk-theme[data-mode^="light"] {
   --property-my-color: red;
 }
 ```
 
-In this case, the CSS selector `.uitk-light` constrains the scope of variable `--property-my-color`. This variable will only be available to style elements that have the CSS class `uitk-light` or are descendants of such an element. This is exactly how a UI Toolkit theme is applied to an application or website. All of the CSS variables that constitute the UI Toolkit theme are scoped to either `.uitk-light` or `.uitk-dark` (more on the distinction between these later). If, at the top level of your application, you have a structure something like this:
+In this case, the CSS selector `.uitk-theme[data-mode^="light"]` constrains the scope of variable `--property-my-color`. This variable will only be available to style elements that have the CSS class `uitk-light` or are descendants of such an element. This is exactly how a UI Toolkit theme is applied to an application or website. All of the CSS variables that constitute the UI Toolkit theme are scoped to either `.uitk-theme[data-mode^="light"]` or `.uitk-theme[data-mode^="dark"]` (more on the distinction between these later). If, at the top level of your application, you have a structure something like this:
 
 ```html
 <div class="MyApplication uitk-light">
@@ -163,7 +156,7 @@ In this case the UI Toolkit theme variables will be available throughout the app
 The UI Toolkit provides a component `ToolkitProvider` for React users that takes care of injecting the appropriate CSS class names into the HTML. Usage would be something like the following:
 
 ```jsx
-<ToolkitProvider density="high" theme="light">
+<ToolkitProvider density="high" mode="light">
   <RestOfMyApplication />
 </ToolkitProvider>
 ```
@@ -183,8 +176,7 @@ The combination of CSS variables with CSS selector scoping is very flexible. It 
 In the CSS where the theme variables are declared, there are sections declared as follows:
 
 ```css
-.uitk-light,
-.uitk-dark {
+.uitk-theme {
   --uitk-actionable-primary-foreground: var(
     --uitk-palette-interact-primary-foreground
   );
@@ -194,10 +186,10 @@ In the CSS where the theme variables are declared, there are sections declared a
 The palette token then resolves down to:
 
 ```css
-.uitk-light {
+.uitk-theme[data-mode^="light"] {
   --uitk-palette-interact-primary-foreground: var(--uitk-grey-900);
 }
-.uitk-dark {
+.uitk-theme[data-mode^="dark"] {
   --uitk-palette-interact-primary-foreground: var(--uitk-white);
 }
 ```

--- a/playground/theme-editor-electron/src/app/themeEditorStyles.css
+++ b/playground/theme-editor-electron/src/app/themeEditorStyles.css
@@ -1,5 +1,4 @@
-.uitk-light,
-.uitk-dark {
+.uitk-theme {
   --uitk-actionable-primary-fontWeight: var(--uitk-typography-fontWeight-bold);
   --uitk-actionable-letterSpacing: 0.6px;
   --uitk-actionable-textTransform: uppercase;
@@ -10,7 +9,7 @@ h1 {
   font-size: 1500px !important;
 }
 
-.uitk-light {
+.uitk-theme[data-mode^="light"] {
   --uitk-actionable-primary-background: var(--uitk-color-grey-60);
   --uitk-actionable-primary-background-active: var(--uitk-color-grey-200);
   --uitk-actionable-primary-background-hover: var(--uitk-color-grey-40);
@@ -36,7 +35,7 @@ h1 {
   --uitk-actionable-secondary-foreground-disabled: rgba(22, 22, 22, var(--uitk-palette-opacity-foreground));
 }
 
-.uitk-dark {
+.uitk-theme[data-mode^="dark"] {
   --uitk-actionable-primary-foreground: var(--uitk-color-white);
   --uitk-actionable-primary-foreground-active: var(--uitk-color-grey-900);
   --uitk-actionable-primary-foreground-hover: var(--uitk-color-white);

--- a/playground/theme-editor-showcase/src/themeEditorStyles.css
+++ b/playground/theme-editor-showcase/src/themeEditorStyles.css
@@ -1,5 +1,4 @@
-.uitk-light,
-.uitk-dark {
+.uitk-theme {
   --uitk-actionable-primary-fontWeight: var(--uitk-typography-fontWeight-bold);
   --uitk-actionable-letterSpacing: 0.6px;
   --uitk-actionable-textTransform: uppercase;
@@ -10,7 +9,7 @@ h1 {
   font-size: 1500px !important;
 }
 
-.uitk-light {
+.uitk-theme[data-mode^="light"] {
   --uitk-actionable-primary-foreground: var(--uitk-color-grey-900);
   --uitk-actionable-primary-foreground-active: var(--uitk-color-white);
   --uitk-actionable-primary-foreground-hover: var(--uitk-color-grey-900);
@@ -35,7 +34,7 @@ h1 {
   --uitk-actionable-secondary-background-hover: var(--uitk-color-grey-40);
 }
 
-.uitk-dark {
+.uitk-theme[data-mode^="dark"] {
   --uitk-actionable-primary-foreground: var(--uitk-color-white);
   --uitk-actionable-primary-foreground-active: var(--uitk-color-grey-900);
   --uitk-actionable-primary-foreground-hover: var(--uitk-color-white);

--- a/tooling/theme-editor/src/helpers/parseToCss.ts
+++ b/tooling/theme-editor/src/helpers/parseToCss.ts
@@ -59,7 +59,7 @@ function transformToCSS(patternJsonByScope) {
   patternJsonByScope.forEach((element) => {
     let selector;
     if (element.scope === "mode-all") {
-      selector = `.uitk-light, .uitk-dark`;
+      selector = `.uitk-theme[data-mode^="light"], .uitk-theme[data-mode^="dark"]`;
     } else if (element.scope === "density-all") {
       selector = `.uitk-density-low, .uitk-density-medium, .uitk-density-high, .uitk-density-touch`;
     } else if (element.scope.includes("emphasis")) {


### PR DESCRIPTION
Adds the concept of theme modes to the toolkit provider. Instead of having two separate themes such as "uitk-light" and "uitk-dark", The toolkit provider will take one theme and one mode as props. To allow another theme to extend the provided theme "uitk-theme"; the class will always be applied to the toolkit provider in addition to the theme name passed. 