### PR TITLE
Dependency clean up

### DIFF
--- a/.changeset/yellow-masks-punch.md
+++ b/.changeset/yellow-masks-punch.md
@@ -1,0 +1,6 @@
+---
+"@jpmorganchase/uitk-core": patch
+"@jpmorganchase/uitk-lab": patch
+---
+
+Remove warning and rely on native console

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^12.1.0",
     "@testing-library/user-event": "^13.2.1",
-    "@types/classnames": "^2.2.11",
     "@types/jest": "^26.0.20",
     "@types/no-scroll": "^2.1.0",
     "@types/node": "^14.14.20",

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "react-window": "^1.8.6",
     "rifm": "^0.12.0",
     "sass": "^1.52.3",
+    "stylelint": "^14.9.1",
     "tinycolor2": "^1.4.2",
     "ts-node": "^10.4.0",
     "typescript": "4.6.4",
@@ -141,8 +142,5 @@
       "<rootDir>/node_modules/csstree-validator"
     ]
   },
-  "packageManager": "yarn@3.2.4",
-  "devDependencies": {
-    "stylelint": "^14.9.1"
-  }
+  "packageManager": "yarn@3.2.4"
 }

--- a/package.json
+++ b/package.json
@@ -116,7 +116,6 @@
     "vite": "^3.1.0",
     "vite-plugin-istanbul": "^3.0.1",
     "vite-tsconfig-paths": "^3.5.0",
-    "warning": "^4.0.3",
     "webpack": "5.74.0"
   },
   "resolutions": {

--- a/packages/core/src/aria-announcer/useAriaAnnouncer.ts
+++ b/packages/core/src/aria-announcer/useAriaAnnouncer.ts
@@ -1,5 +1,4 @@
 import { useCallback, useContext, useEffect, useMemo, useRef } from "react";
-import warning from "warning";
 import { debounce } from "../utils/debounce";
 import { AriaAnnouncer, AriaAnnouncerContext } from "./AriaAnnouncerContext";
 
@@ -10,6 +9,8 @@ export type useAriaAnnouncerHook = (
   options?: useAnnouncerOptions
 ) => AriaAnnouncer;
 
+let warnedOnce = false;
+
 export const useAriaAnnouncer: useAriaAnnouncerHook = ({
   debounce: debounceInterval = 0,
 } = {}) => {
@@ -19,10 +20,14 @@ export const useAriaAnnouncer: useAriaAnnouncerHook = ({
     (announcement: string, delay?: number) => {
       const isReactAnnouncerInstalled = context && context.announce;
 
-      warning(
-        isReactAnnouncerInstalled,
-        "useAriaAnnouncer is being used without an AriaAnnouncerProvider. Your application should be wrapped in an AriaAnnouncerProvider"
-      );
+      if (process.env.NODE_ENV !== "production") {
+        if (isReactAnnouncerInstalled && warnedOnce) {
+          console.warn(
+            "useAriaAnnouncer is being used without an AriaAnnouncerProvider. Your application should be wrapped in an AriaAnnouncerProvider"
+          );
+          warnedOnce = true;
+        }
+      }
 
       function makeAnnouncement() {
         if (mountedRef.current) {

--- a/packages/core/src/layout/BorderLayout/BorderLayout.tsx
+++ b/packages/core/src/layout/BorderLayout/BorderLayout.tsx
@@ -6,7 +6,6 @@ import {
   useEffect,
 } from "react";
 import cx from "classnames";
-import warning from "warning";
 
 import { GridLayout, GridLayoutProps } from "../GridLayout";
 import { makePrefixer } from "../../utils";
@@ -58,16 +57,17 @@ export const BorderLayout = forwardRef<HTMLDivElement, BorderLayoutProps>(
 
     const gridTemplateAreas = `"${topSection}" "${midSection}" "${bottomSection}"`;
 
+    const hasMainSection = borderAreas.includes("main");
+
     useEffect(() => {
       if (process.env.NODE_ENV !== "production") {
-        const hasMainSection = borderAreas.includes("main");
-
-        warning(
-          hasMainSection,
-          "No main section has been found. A main section should be provided."
-        );
+        if (!hasMainSection) {
+          console.warn(
+            "No main section has been found. A main section should be provided."
+          );
+        }
       }
-    }, [borderAreas, children]);
+    }, [hasMainSection]);
 
     const borderLayoutStyles = {
       ...style,

--- a/packages/lab/src/breadcrumbs/Breadcrumbs.tsx
+++ b/packages/lab/src/breadcrumbs/Breadcrumbs.tsx
@@ -7,7 +7,6 @@ import React, {
   ReactNode,
   useMemo,
 } from "react";
-import warning from "warning";
 import { BreadcrumbProps } from "./Breadcrumb";
 import { BreadcrumbsCollapsed } from "./internal/BreadcrumbsCollapsed";
 import { BreadcrumbsContext } from "./internal/BreadcrumbsContext";
@@ -112,8 +111,7 @@ export const Breadcrumbs = React.forwardRef<HTMLElement, BreadcrumbsProps>(
       // This defends against someone passing weird input, to ensure that if all
       // items would be shown anyway, we just show all items without the EllipsisItem
       if (itemsBeforeCollapse + itemsAfterCollapse >= allItems.length) {
-        warning(
-          false,
+        console.warn(
           [
             "You have provided an invalid combination of properties to the Breadcrumbs.",
             `itemsAfterCollapse={${itemsAfterCollapse}} +itemsBeforeCollapse={${itemsBeforeCollapse}} >= maxItems={${maxItems}}`,

--- a/packages/lab/src/carousel/Carousel.tsx
+++ b/packages/lab/src/carousel/Carousel.tsx
@@ -1,10 +1,10 @@
 import {
   Button,
-  makePrefixer,
-  useId,
-  RadioButtonGroup,
-  GridLayout,
   DeckLayout,
+  GridLayout,
+  makePrefixer,
+  RadioButtonGroup,
+  useId,
 } from "@jpmorganchase/uitk-core";
 import {
   ChangeEventHandler,
@@ -15,7 +15,6 @@ import {
   useEffect,
 } from "react";
 import { ChevronLeftIcon, ChevronRightIcon } from "@jpmorganchase/uitk-icons";
-import warning from "warning";
 import cx from "classnames";
 import "./Carousel.css";
 import { useSlideSelection } from "../utils";
@@ -95,13 +94,13 @@ export const Carousel = forwardRef<HTMLDivElement, CarouselProps>(
 
     useEffect(() => {
       if (process.env.NODE_ENV !== "production") {
-        const validNumberOfChildren = slidesCount > 1;
-        warning(
-          validNumberOfChildren,
-          "Carousel component requires more than one children to render. At least two elements should be provided."
-        );
+        if (slidesCount < 1) {
+          console.warn(
+            "Carousel component requires more than one children to render. At least two elements should be provided."
+          );
+        }
       }
-    }, [children]);
+    }, [slidesCount]);
 
     return (
       <GridLayout

--- a/packages/lab/src/combo-box-deprecated/ComboBoxDeprecated.tsx
+++ b/packages/lab/src/combo-box-deprecated/ComboBoxDeprecated.tsx
@@ -6,7 +6,6 @@ import {
 } from "@jpmorganchase/uitk-core";
 import classnames from "classnames";
 import { ComponentType, forwardRef, Ref, useRef } from "react";
-import warning from "warning";
 
 import {
   DefaultComboBox,
@@ -45,10 +44,9 @@ const validateProps = ({
   delimiter?: string | string[];
 }) => {
   if (process.env.NODE_ENV !== "production") {
-    warning(
-      isMultiSelect || (!isMultiSelect && !delimiter),
-      "Delimiter can only be used for a multi-select combo-box."
-    );
+    if (!isMultiSelect && delimiter) {
+      console.warn("Delimiter can only be used for a multi-select combo-box.");
+    }
   }
 };
 

--- a/packages/lab/src/list-deprecated/useList.ts
+++ b/packages/lab/src/list-deprecated/useList.ts
@@ -26,8 +26,6 @@ import {
   ListSelectionVariant,
 } from "./ListProps";
 
-import warning from "warning";
-
 type keyHandler = (event: KeyboardEvent<HTMLInputElement>) => void;
 
 interface listBoxAriaProps
@@ -610,25 +608,26 @@ const validateProps = <Item, Variant extends ListSelectionVariant>(
     const hasNoIndexer =
       getItemIndex === undefined && getItemAtIndex === undefined;
 
-    /* eslint-disable react-hooks/rules-of-hooks */
-    useEffect(() => {
-      warning(
-        source == null || Array.isArray(source),
-        "`source` for useList must be an array."
-      );
-    }, [source]);
+    const sourceNotArray = !Array.isArray(source);
 
     useEffect(() => {
-      warning(
-        hasNoIndexer || hasIndexer,
-        "useList needs to have both `getItemIndex` and `getItemAtIndex`."
-      );
+      if (sourceNotArray) {
+        console.error("`source` for useList must be an array.");
+      }
+    }, [sourceNotArray]);
 
-      warning(
-        hasNoIndexer || itemCount !== undefined,
-        "useList needs to have `itemCount` if an indexer is used."
-      );
+    useEffect(() => {
+      if (!hasNoIndexer && !hasIndexer) {
+        console.error(
+          "useList needs to have both `getItemIndex` and `getItemAtIndex`."
+        );
+      }
+
+      if (!hasNoIndexer && itemCount === undefined) {
+        console.error(
+          "useList needs to have `itemCount` if an indexer is used."
+        );
+      }
     }, [hasIndexer, hasNoIndexer, itemCount]);
-    /* eslint-enable react-hooks/rules-of-hooks */
   }
 };

--- a/packages/lab/src/metric/MetricHeader.tsx
+++ b/packages/lab/src/metric/MetricHeader.tsx
@@ -1,7 +1,6 @@
 import { makePrefixer } from "@jpmorganchase/uitk-core";
 import cx from "classnames";
 import { forwardRef, HTMLAttributes, useCallback } from "react";
-import warning from "warning";
 import { Link, LinkProps } from "../link";
 import { Div } from "../text";
 import { useMetricContext } from "./internal";
@@ -13,7 +12,7 @@ export interface MetricHeaderProps extends HTMLAttributes<HTMLDivElement> {
    *
    * @see `Link` for a list of valid props.
    */
-  SubtitleLinkProps?: Partial<LinkProps>;
+  SubtitleLinkProps?: Omit<Partial<LinkProps>, "children">;
   /**
    * Subtitle of the Metric Header
    */
@@ -47,14 +46,7 @@ export const MetricHeader = forwardRef<HTMLDivElement, MetricHeaderProps>(
       );
 
       if (SubtitleLinkProps) {
-        const { children, href = "", ...restLinkProps } = SubtitleLinkProps;
-
-        if (process.env.NODE_ENV !== "production") {
-          warning(
-            children === undefined,
-            `'children' in 'SubtitleLinkProps' is ignored. ${subtitle} is used instead.`
-          );
-        }
+        const { href = "", ...restLinkProps } = SubtitleLinkProps;
 
         return (
           <Link href={href} {...restLinkProps}>

--- a/packages/lab/src/tokenized-input/TokenizedInputBase.tsx
+++ b/packages/lab/src/tokenized-input/TokenizedInputBase.tsx
@@ -17,13 +17,12 @@ import {
   useRef,
   useState,
 } from "react";
-import warning from "warning";
 import {
   Button,
   ButtonProps,
-  makePrefixer,
   Input,
   InputProps,
+  makePrefixer,
   useDensity,
   useForkRef,
   useId,
@@ -85,10 +84,11 @@ const getItemsAriaLabel = (itemCount: number) =>
 
 const hasHelpers = (helpers: any) => {
   if (process.env.NODE_ENV !== "production") {
-    warning(
-      helpers != null,
-      'TokenizedInputBase is used without helpers. You should pass in "helpers" from "useTokenizedInput".'
-    );
+    if (helpers == null) {
+      console.warn(
+        'TokenizedInputBase is used without helpers. You should pass in "helpers" from "useTokenizedInput".'
+      );
+    }
   }
   return helpers != null;
 };

--- a/packages/lab/src/tokenized-input/internal/defaultItemToString.ts
+++ b/packages/lab/src/tokenized-input/internal/defaultItemToString.ts
@@ -1,5 +1,3 @@
-import warning from "warning";
-
 import { isPlainObject } from "./isPlainObject";
 
 export const defaultItemToString = (item: any) => {
@@ -12,8 +10,7 @@ export const defaultItemToString = (item: any) => {
   }
 
   if (process.env.NODE_ENV !== "production") {
-    warning(
-      false,
+    console.warn(
       [
         "itemToString: you've likely forgotten to set the label prop on the item object.",
         "You can also provide your own `itemToString` implementation.",

--- a/packages/lab/src/tokenized-input/useTokenizedInput.tsx
+++ b/packages/lab/src/tokenized-input/useTokenizedInput.tsx
@@ -1,11 +1,11 @@
 //TODO remove when popout code has been migrated
 /* eslint-disable @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access */
 import {
+  ownerWindow,
   useControlled,
   useDensity,
   useFormFieldProps,
   useId,
-  ownerWindow,
 } from "@jpmorganchase/uitk-core";
 import copy from "clipboard-copy";
 import {
@@ -22,7 +22,6 @@ import {
   useRef,
   useState,
 } from "react";
-import warning from "warning";
 import { escapeRegExp, useEventCallback } from "../utils";
 import { defaultItemToString } from "./internal/defaultItemToString";
 import { getCursorPosition } from "./internal/getCursorPosition";
@@ -575,7 +574,7 @@ export function useTokenizedInput<Item>(
               return result;
             })
             .catch((error) => {
-              warning(false, error);
+              console.error(error);
             });
           break;
         case "V":
@@ -707,18 +706,17 @@ const validateProps = function validateProps<Item>(
   if (process.env.NODE_ENV !== "production") {
     const { delimiter } = props;
 
-    /* eslint-disable react-hooks/rules-of-hooks */
+    const invalidDelimiter = Array.isArray(delimiter)
+      ? delimiter.every(isChar)
+      : isChar(delimiter);
+
     useEffect(() => {
-      warning(
-        delimiter == null ||
-          isValidDelimiter(delimiter) ||
-          (Array.isArray(delimiter) && delimiter.every(isValidDelimiter)),
+      console.warn(
         "TokenizedInput delimiter should be a single character or an array of single characters"
       );
-    }, [delimiter]);
-    /* eslint-enable react-hooks/rules-of-hooks */
+    }, [invalidDelimiter]);
   }
 };
 
-const isValidDelimiter = (value: unknown) =>
+const isChar = (value: unknown) =>
   typeof value === "string" && value.length === 1;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3372,7 +3372,6 @@ __metadata:
     vite: ^3.1.0
     vite-plugin-istanbul: ^3.0.1
     vite-tsconfig-paths: ^3.5.0
-    warning: ^4.0.3
     webpack: 5.74.0
   languageName: unknown
   linkType: soft
@@ -25000,15 +24999,6 @@ __metadata:
   dependencies:
     makeerror: 1.0.12
   checksum: ad7a257ea1e662e57ef2e018f97b3c02a7240ad5093c392186ce0bcf1f1a60bbadd520d073b9beb921ed99f64f065efb63dfc8eec689a80e569f93c1c5d5e16c
-  languageName: node
-  linkType: hard
-
-"warning@npm:^4.0.3":
-  version: 4.0.3
-  resolution: "warning@npm:4.0.3"
-  dependencies:
-    loose-envify: ^1.0.0
-  checksum: 4f2cb6a9575e4faf71ddad9ad1ae7a00d0a75d24521c193fa464f30e6b04027bd97aa5d9546b0e13d3a150ab402eda216d59c1d0f2d6ca60124d96cd40dfa35c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3320,7 +3320,6 @@ __metadata:
     "@testing-library/jest-dom": ^5.14.1
     "@testing-library/react": ^12.1.0
     "@testing-library/user-event": ^13.2.1
-    "@types/classnames": ^2.2.11
     "@types/jest": ^26.0.20
     "@types/no-scroll": ^2.1.0
     "@types/node": ^14.14.20
@@ -5546,15 +5545,6 @@ __metadata:
   version: 3.0.1
   resolution: "@types/braces@npm:3.0.1"
   checksum: 3749f7673a03d498ddb2f199b222bb403e53e78ac05a599c757c2049703ece802602c78640af0ff826be0fd2ea8b03daff04ce18806ed739592302195b7a569b
-  languageName: node
-  linkType: hard
-
-"@types/classnames@npm:^2.2.11":
-  version: 2.3.0
-  resolution: "@types/classnames@npm:2.3.0"
-  dependencies:
-    classnames: "*"
-  checksum: e1bd6de60fc5e4ead601838078b10f378d6a66ad21112922856de59a1f450b1361f597aa3ca34f2cc33bc030f950112872fddfde43c5189bec89737a8b237f24
   languageName: node
   linkType: hard
 
@@ -9003,7 +8993,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"classnames@npm:*, classnames@npm:^2.2.6":
+"classnames@npm:^2.2.6":
   version: 2.3.1
   resolution: "classnames@npm:2.3.1"
   checksum: 14db8889d56c267a591f08b0834989fe542d47fac659af5a539e110cc4266694e8de86e4e3bbd271157dbd831361310a8293e0167141e80b0f03a0f175c80960


### PR DESCRIPTION
`@types/classnames` is a stub dependency and isn't needed
Moved stylelint so it's more consistent
Removed warning and rely on native console functionality