### PR TITLE
Fix generic default string type for List, Dropdown and Combobox

### DIFF
--- a/.changeset/quick-rocks-remain.md
+++ b/.changeset/quick-rocks-remain.md
@@ -1,0 +1,5 @@
+---
+"@jpmorganchase/uitk-lab": patch
+---
+
+Fix default generic Item type to be `string` for ListProps, DropdownProps and ComboBox

--- a/packages/lab/src/combo-box/ComboBox.tsx
+++ b/packages/lab/src/combo-box/ComboBox.tsx
@@ -47,7 +47,7 @@ export interface ComboBoxProps<
 }
 
 export const ComboBox = forwardRef(function Combobox<
-  Item = "string",
+  Item = string,
   Selection extends SelectionStrategy = "default"
 >(
   {

--- a/packages/lab/src/dropdown/Dropdown.tsx
+++ b/packages/lab/src/dropdown/Dropdown.tsx
@@ -26,7 +26,7 @@ import { useDropdown } from "./useDropdown";
 import { forwardCallbackProps } from "../utils";
 
 export interface DropdownProps<
-  Item = "string",
+  Item = string,
   Selection extends SelectionStrategy = "default"
 > extends DropdownBaseProps,
     Pick<
@@ -41,7 +41,7 @@ export interface DropdownProps<
 }
 
 export const Dropdown = forwardRef(function Dropdown<
-  Item = "string",
+  Item = string,
   Selection extends SelectionStrategy = "default"
 >(
   {

--- a/packages/lab/src/list-deprecated/useList.ts
+++ b/packages/lab/src/list-deprecated/useList.ts
@@ -36,7 +36,7 @@ interface listBoxAriaProps
   role: string; // We will default it to be 'listbox', but users can override
 }
 export interface ListState<
-  Item = "string",
+  Item = string,
   Variant extends ListSelectionVariant = "default"
 > {
   id: string;
@@ -49,7 +49,7 @@ export interface ListState<
 }
 
 export interface ListHelpers<
-  Item = "string",
+  Item = string,
   Variant extends ListSelectionVariant = "default"
 > {
   setFocusVisible: (visible: boolean) => void;

--- a/packages/lab/stories/dropdown.stories.tsx
+++ b/packages/lab/stories/dropdown.stories.tsx
@@ -20,19 +20,19 @@ import {
   DropdownProps,
   ListItem,
   ListItemType,
+  SelectionChangeHandler,
 } from "@jpmorganchase/uitk-lab";
 import { usa_states } from "./list.data";
-
-import { SelectionChangeHandler } from "../src/common-hooks";
 
 export default {
   title: "Lab/Dropdown",
   component: Dropdown,
 };
 
-export const DefaultDropdown: Story<DropdownProps> = () => {
+export const DefaultDropdown: Story<DropdownProps> = (props) => {
   const handleChange: SelectionChangeHandler = (event, selectedItem) => {
     console.log("selection changed", selectedItem);
+    props.onSelectionChange?.(event, selectedItem);
   };
   return (
     <Dropdown
@@ -43,15 +43,19 @@ export const DefaultDropdown: Story<DropdownProps> = () => {
   );
 };
 
-export const MultiSelectDropdownExample: Story<DropdownProps> = () => {
+export const MultiSelectDropdownExample: Story<
+  DropdownProps<string, "multiple">
+> = (props) => {
   const handleChange: SelectionChangeHandler<string, "multiple"> = (
     _e,
-    [items]
+    items
   ) => {
     console.log({ selected: items });
+    props.onSelectionChange?.(_e, items);
   };
   return (
     <Dropdown
+      {...props}
       defaultSelected={["California", "Colorado"]}
       onSelectionChange={handleChange}
       selectionStrategy="multiple"
@@ -72,12 +76,13 @@ const objectOptionsExampleData: objectOptionType[] = [
   { value: 40, text: "D Option", id: 4 },
 ];
 
-export const ItemToString: Story<DropdownProps<objectOptionType>> = () => {
+export const ItemToString: Story<DropdownProps<objectOptionType>> = (props) => {
   const itemToString = (item: objectOptionType) => {
     return item ? item.text : "";
   };
   return (
     <Dropdown<objectOptionType>
+      {...props}
       defaultSelected={objectOptionsExampleData[0]}
       itemToString={itemToString}
       source={objectOptionsExampleData}
@@ -85,19 +90,25 @@ export const ItemToString: Story<DropdownProps<objectOptionType>> = () => {
   );
 };
 
-export const CustomButton: Story<DropdownProps> = () => {
+export const CustomButton: Story<DropdownProps> = (props) => {
   const [isOpen, setIsOpen] = useState(false);
   const [selectedValue, setSelectedValue] = useState("Arkansas");
+  const handleOpenChange = (isOpen: boolean) => {
+    setIsOpen(isOpen);
+    props.onOpenChange?.(isOpen);
+  };
   const handleChange: SelectionChangeHandler = (event, selectedItem) => {
     if (selectedItem) {
       setSelectedValue(selectedItem);
     }
+    props.onSelectionChange?.(event, selectedItem);
   };
 
   return (
     <Dropdown
+      {...props}
       selected={selectedValue}
-      onOpenChange={setIsOpen}
+      onOpenChange={handleOpenChange}
       onSelectionChange={handleChange}
       placement="bottom-end"
       source={usa_states}
@@ -129,18 +140,16 @@ const ItalicListItem: ListItemType<string> = ({ item, ...props }) => {
   );
 };
 
-export const CustomRowRenderer: Story<DropdownProps> = () => (
+export const CustomRowRenderer: Story<DropdownProps> = (props) => (
   <Dropdown
+    {...props}
     ListItem={ItalicListItem}
     defaultSelected={usa_states[0]}
     source={usa_states}
   />
 );
 
-const ListItemWithTooltip: ListItemType<string> = ({
-  item = "uknown",
-  ...props
-}) => {
+const ListItemWithTooltip: ListItemType<string> = ({ item, ...props }) => {
   const { getTriggerProps, getTooltipProps } = useTooltip({
     placement: "right",
   });
@@ -155,8 +164,9 @@ const ListItemWithTooltip: ListItemType<string> = ({
   );
 };
 
-export const CustomRowRendererWithTooltip: Story<DropdownProps> = () => (
+export const CustomRowRendererWithTooltip: Story<DropdownProps> = (props) => (
   <Dropdown
+    {...props}
     ListItem={ListItemWithTooltip}
     source={usa_states}
     defaultSelected={usa_states[0]}
@@ -189,7 +199,7 @@ export const WithFormFieldLabelLeft: Story<DropdownProps> = () => {
 
 // We supply `height` to the div so that the popper can be captured in visual
 // regression test
-export const InitialIsOpen: Story<DropdownProps> = () => {
+export const InitialIsOpen: Story<DropdownProps> = (props) => {
   return (
     <div style={{ width: 250, height: 500 }}>
       <FormField
@@ -197,6 +207,7 @@ export const InitialIsOpen: Story<DropdownProps> = () => {
         label="ADA compliant label"
       >
         <Dropdown
+          {...props}
           defaultSelected={usa_states[2]}
           defaultIsOpen
           source={usa_states}
@@ -209,16 +220,18 @@ export const InitialIsOpen: Story<DropdownProps> = () => {
 const constArray = ["A", "B", "C"] as const;
 
 /** Illustration of using readonly source */
-export const ConstReadonlySource: Story<DropdownProps> = () => (
-  <Dropdown defaultSelected={constArray[0]} source={constArray} />
+export const ConstReadonlySource: Story<DropdownProps> = (props) => (
+  <Dropdown {...props} defaultSelected={constArray[0]} source={constArray} />
 );
 
-export const DisabledDropdownList: Story<DropdownProps> = () => {
+export const DisabledDropdownList: Story<DropdownProps> = (props) => {
   const handleChange: SelectionChangeHandler = (event, selectedItem) => {
     console.log("selection changed", selectedItem);
+    props.onSelectionChange?.(event, selectedItem);
   };
   return (
     <Dropdown
+      {...props}
       disabled
       id="test"
       onSelectionChange={handleChange}
@@ -228,14 +241,16 @@ export const DisabledDropdownList: Story<DropdownProps> = () => {
   );
 };
 
-export const ControlledOpenDropdown: Story<DropdownProps> = () => {
+export const ControlledOpenDropdown: Story<DropdownProps> = (props) => {
   const [isOpen, setIsOpen] = useState(true);
   const handleChange: any = (open: boolean) => {
     console.log({ openChanged: open });
+    setIsOpen(open);
+    props.onOpenChange?.(open);
   };
   const toggleDropdown = useCallback(() => {
     console.log(`toggleDropdoen isOpen = ${isOpen}`);
-    setIsOpen(!isOpen);
+    setIsOpen((x) => !x);
   }, [isOpen]);
   return (
     <>
@@ -243,6 +258,7 @@ export const ControlledOpenDropdown: Story<DropdownProps> = () => {
         {isOpen ? "Hide Dropdown" : "Show Dropdown"}
       </Button>
       <Dropdown
+        {...props}
         isOpen={isOpen}
         defaultSelected="Alaska"
         onOpenChange={handleChange}
@@ -253,7 +269,7 @@ export const ControlledOpenDropdown: Story<DropdownProps> = () => {
   );
 };
 
-export const FullyControlledDropdown: Story<DropdownProps> = () => {
+export const FullyControlledDropdown: Story<DropdownProps> = (props) => {
   const [open, setOpen] = useState(false);
   const [highlightedIndex, setHighlightedIndex] = useState(-1);
   const [selectedItem, setSelectedItem] = useState<string | null>(null);
@@ -280,6 +296,7 @@ export const FullyControlledDropdown: Story<DropdownProps> = () => {
   return (
     <div style={{ display: "inline-flex", gap: 16 }}>
       <Dropdown
+        {...props}
         ListProps={{
           highlightedIndex,
         }}

--- a/packages/lab/stories/list.stories.tsx
+++ b/packages/lab/stories/list.stories.tsx
@@ -31,8 +31,9 @@ import {
   ListProps,
   ListScrollHandles,
   VirtualizedList,
+  SelectionChangeHandler,
 } from "@jpmorganchase/uitk-lab";
-import { SelectHandler, SelectionChangeHandler } from "../src/common-hooks";
+import { SelectHandler } from "../src/common-hooks";
 
 import { usa_states } from "./list.data";
 
@@ -62,9 +63,14 @@ export default {
   decorators: [withFullViewWidth],
 } as ComponentMeta<typeof List>;
 
-export const Default: Story<ListProps> = () => {
+export const Default: Story<ListProps> = (props) => {
   return (
-    <List aria-label="Listbox example" maxWidth={292} source={usa_states} />
+    <List
+      {...props}
+      aria-label="Listbox example"
+      maxWidth={292}
+      source={usa_states}
+    />
   );
 };
 
@@ -78,9 +84,10 @@ export const BorderlessList: Story<ListProps> = (props) => (
   />
 );
 
-export const DeclarativeList: Story<ListProps> = () => {
+export const DeclarativeList: Story<ListProps> = (props) => {
   return (
     <List
+      {...props}
       aria-label="Declarative List example"
       displayedItemCount={5}
       width={292}


### PR DESCRIPTION
- Generic `Item` type of List family components should be `string` not string literal type `"string"`
- Adding `props` spreading to stories so Storybook's Actions panel will display correctly for handlers (with existing setup [here](https://github.com/jpmorganchase/uitk/blob/6338ff7101b267be268a94b0a3e5821f3fe2fea8/.storybook/preview.tsx#L81))

![Storybook Actions Panel](https://user-images.githubusercontent.com/5257855/202158710-97ff98bb-fd85-4f89-9bd7-a5e05ee35235.jpeg)