### PR TITLE
Remove container border color variants

### DIFF
--- a/.changeset/tricky-roses-judge.md
+++ b/.changeset/tricky-roses-judge.md
@@ -1,0 +1,12 @@
+---
+"@jpmorganchase/uitk-lab": minor
+"@jpmorganchase/uitk-theme": minor
+---
+
+Remove container border color variants; replace usage with respective emphasis token
+
+```diff
+- --uitk-container-cta-borderColor
+- --uitk-container-primary-borderColor
+- --uitk-container-secondary-borderColor
+```

--- a/packages/lab/src/toggle-button/ToggleButtonGroup.css
+++ b/packages/lab/src/toggle-button/ToggleButtonGroup.css
@@ -12,10 +12,10 @@
 }
 
 .uitkToggleButtonGroup.uitkToggleButtonGroup-cta {
-  --toggleButton-group-borderColor: var(--uitkToggleButton-group-cta-borderColor, var(--uitk-container-cta-borderColor));
+  --toggleButton-group-borderColor: var(--uitkToggleButton-group-cta-borderColor, var(--uitk-container-borderColor-high));
 }
 .uitkToggleButtonGroup.uitkToggleButtonGroup-primary {
-  --toggleButton-group-borderColor: var(--uitkToggleButton-group-primary-borderColor, var(--uitk-container-primary-borderColor));
+  --toggleButton-group-borderColor: var(--uitkToggleButton-group-primary-borderColor, var(--uitk-container-borderColor-medium));
 }
 
 .uitkToggleButtonGroup {
@@ -29,7 +29,7 @@
 }
 
 .uitkToggleButtonGroup.uitkToggleButtonGroup-secondary {
-  --toggleButton-group-borderColor: var(--uitkToggleButton-group-secondary-borderColor, var(--uitk-container-secondary-borderColor));
+  --toggleButton-group-borderColor: var(--uitkToggleButton-group-secondary-borderColor, var(--uitk-container-borderColor-low));
 }
 
 .uitkToggleButtonGroup-horizontal .uitkToggleButton {

--- a/packages/theme/css/characteristics/container.css
+++ b/packages/theme/css/characteristics/container.css
@@ -2,10 +2,6 @@
   --uitk-container-borderStyle: solid;
   --uitk-container-borderWidth: 1px;
 
-  --uitk-container-cta-borderColor: var(--uitk-palette-neutral-cta-border);
-  --uitk-container-primary-borderColor: var(--uitk-palette-neutral-primary-border);
-  --uitk-container-secondary-borderColor: var(--uitk-palette-neutral-secondary-border);
-
   --uitk-container-background-low: var(--uitk-palette-neutral-background-low);
   --uitk-container-background-medium: var(--uitk-palette-neutral-background-medium);
   --uitk-container-background-high: var(--uitk-palette-neutral-background-high);

--- a/packages/theme/stories/characteristics/container.stories.mdx
+++ b/packages/theme/stories/characteristics/container.stories.mdx
@@ -26,8 +26,6 @@ allow hierarchical organization.
       <LineBlockCell />
       <LineBlockCode>--uitk-container-borderStyle</LineBlockCode>
       <LineBlock lineWidth="--uitk-container-borderWidth" />
-      <ColorBlock colorVar="--uitk-container-primary-borderColor" />
-      <ColorBlock colorVar="--uitk-container-cta-borderColor" />
     </DocGrid>
   </Story>
 </Canvas>
@@ -64,18 +62,6 @@ allow hierarchical organization.
       <ColorBlock colorVar="--uitk-container-background-low" />
       <ColorBlock colorVar="--uitk-container-borderColor-low" />
       <ColorBlock colorVar="--uitk-container-borderColor-disabled-low" />
-    </DocGrid>
-  </Story>
-</Canvas>
-
-### Variants
-
-<Canvas>
-  <Story name="Variants">
-    <DocGrid>
-      <ColorBlock colorVar="--uitk-container-cta-borderColor" />
-      <ColorBlock colorVar="--uitk-container-primary-borderColor" />
-      <ColorBlock colorVar="--uitk-container-secondary-borderColor" />
     </DocGrid>
   </Story>
 </Canvas>


### PR DESCRIPTION
Figma feedback- remove container border color variants, they can be replaced with the same values via emphasis