### PR TITLE
Stop nested ViewportProviders creating multiple ResizeObservers

### DIFF
--- a/.changeset/gold-bees-try.md
+++ b/.changeset/gold-bees-try.md
@@ -1,0 +1,5 @@
+---
+"@jpmorganchase/uitk-core": patch
+---
+
+Nested ToolkitProviders no longer create multiple ResizeObservers to detect viewport width

--- a/packages/core/src/__tests__/viewport-provider/ViewportProvider.spec.tsx
+++ b/packages/core/src/__tests__/viewport-provider/ViewportProvider.spec.tsx
@@ -1,0 +1,89 @@
+import { render } from "@testing-library/react";
+import { ViewportProvider, ViewportContext } from "../../viewport";
+
+const createMockResizeObserver = () => {
+  const MockResizeObserver = jest
+    .fn()
+    .mockImplementation((callback: (data: any) => void) => {
+      const storedCallback = () =>
+        callback([
+          {
+            contentRect: {
+              width: 100,
+            },
+          },
+        ]);
+
+      return {
+        observe: jest.fn().mockImplementation(() => {
+          storedCallback();
+        }),
+        disconnect: jest.fn(),
+      };
+    });
+
+  global.ResizeObserver = MockResizeObserver;
+};
+
+describe("GIVEN a ViewportProvider", () => {
+  describe("WHEN there is no parent ViewportProvider", () => {
+    it("THEN it should create a ResizeObserver", () => {
+      createMockResizeObserver();
+
+      render(<ViewportProvider />);
+      expect(global.ResizeObserver).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("WHEN there is a parent ViewportProvider", () => {
+    it("THEN it should not create an additional ResizeObserver", () => {
+      createMockResizeObserver();
+
+      render(
+        <ViewportProvider>
+          <ViewportProvider />
+        </ViewportProvider>
+      );
+      expect(global.ResizeObserver).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("WHEN ViewportContext is not null", () => {
+    it("THEN it should not create an additional ResizeObserver", () => {
+      createMockResizeObserver();
+
+      render(
+        <ViewportContext.Provider value={100}>
+          <ViewportProvider />
+        </ViewportContext.Provider>
+      );
+      expect(global.ResizeObserver).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe("WHEN ViewportContext is zero", () => {
+    it("THEN it should not create an additional ResizeObserver", () => {
+      createMockResizeObserver();
+
+      render(
+        <ViewportContext.Provider value={0}>
+          <ViewportProvider />
+        </ViewportContext.Provider>
+      );
+      expect(global.ResizeObserver).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe("WHEN ViewportContext is null", () => {
+    it("THEN it should create an additional ResizeObserver", () => {
+      createMockResizeObserver();
+
+      render(
+        <ViewportContext.Provider value={null}>
+          <ViewportProvider />
+        </ViewportContext.Provider>
+      );
+      expect(global.ResizeObserver).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/core/src/viewport/ViewportProvider.tsx
+++ b/packages/core/src/viewport/ViewportProvider.tsx
@@ -1,37 +1,55 @@
 import {
   createContext,
-  useEffect,
+  useLayoutEffect,
   useState,
   useContext,
   ReactNode,
 } from "react";
 
-const ViewportContext = createContext(0);
+const ViewportContext = createContext<number | null>(null);
 
-const ViewportProvider = ({ children }: { children?: ReactNode }) => {
-  const [viewport, setViewport] = useState(0);
+type ViewportProviderProps = {
+  children?: ReactNode;
+};
 
-  useEffect(() => {
-    const observer = new ResizeObserver(
-      (observerEntries: ResizeObserverEntry[]) => {
-        setViewport(observerEntries[0].contentRect.width);
-      }
-    );
-    observer.observe(document.body);
+const ViewportProvider = ({ children }: ViewportProviderProps) => {
+  // Get value directly from the ViewportContext so we can detect if the value is null (no inherited ViewportProvider)
+  const existingViewport = useContext(ViewportContext);
+  const [viewport, setViewport] = useState(existingViewport);
+
+  const noExistingViewport = existingViewport === null;
+  const viewportValue = existingViewport || viewport || 0;
+
+  useLayoutEffect(() => {
+    let observer: ResizeObserver | null = null;
+
+    if (noExistingViewport) {
+      observer = new ResizeObserver(
+        (observerEntries: ResizeObserverEntry[]) => {
+          setViewport(observerEntries[0].contentRect.width);
+        }
+      );
+
+      observer.observe(document.body);
+    }
+
     return () => {
-      observer.disconnect();
+      if (observer) {
+        observer.disconnect();
+      }
     };
-  }, []);
+  }, [noExistingViewport]);
 
   return (
-    <ViewportContext.Provider value={viewport}>
+    <ViewportContext.Provider value={viewportValue}>
       {children}
     </ViewportContext.Provider>
   );
 };
 
-const useViewport = () => {
-  return useContext(ViewportContext);
+const useViewport = (): number => {
+  const value = useContext(ViewportContext);
+  return value === null ? 0 : value;
 };
 
 export { ViewportProvider, ViewportContext, useViewport };


### PR DESCRIPTION
use single ResizeObserver for nested ViewportProviders to detect viewport width