### PR TITLE
Add default width and height to grid

### DIFF
--- a/.changeset/red-jokes-obey.md
+++ b/.changeset/red-jokes-obey.md
@@ -1,0 +1,5 @@
+---
+"@jpmorganchase/uitk-grid": patch
+---
+
+Add default width and height to grid. Use `--uitkGrid-width` and `--uitkGrid-height` to provide a custom size.

--- a/packages/grid/src/Grid.css
+++ b/packages/grid/src/Grid.css
@@ -175,6 +175,9 @@
   outline: none;
   user-select: none;
   background: var(--grid-background);
+  
+  width: var(--uitkGrid-width, var(--grid-total-width));
+  height: var(--uitkGrid-height, var(--grid-total-height));
 }
 
 /* Styles applied to the root element if zebra is enabled */


### PR DESCRIPTION
Current Grid doesn't have any size, so using `<Grid rowData={rowData} />` without any class or style will result in all rows not visible, which is super confusing. Using total width and height variable as default value to accommodate this. 