### PR TITLE
Row selection checkbox gets focus

### DIFF
--- a/.changeset/violet-yaks-begin.md
+++ b/.changeset/violet-yaks-begin.md
@@ -1,0 +1,5 @@
+---
+"@jpmorganchase/uitk-grid": patch
+---
+
+Row selection checkbox/radio button gets focus

--- a/packages/grid/src/BaseCell.tsx
+++ b/packages/grid/src/BaseCell.tsx
@@ -3,6 +3,7 @@ import "./BaseCell.css";
 import { makePrefixer } from "@jpmorganchase/uitk-core";
 import { GridCellProps } from "./GridColumn";
 import { GridColumnModel } from "./Grid";
+import { useEffect, useRef } from "react";
 
 const withBaseName = makePrefixer("uitkGridBaseCell");
 
@@ -24,8 +25,22 @@ export function BaseCell<T>(props: GridCellProps<T>) {
     children,
   } = props;
 
+  const tdRef = useRef<HTMLTableCellElement>(null);
+
+  useEffect(() => {
+    if (isFocused && tdRef.current) {
+      const nestedInteractive = tdRef.current.querySelector(`[tabindex="0"]`);
+      if (nestedInteractive) {
+        (nestedInteractive as HTMLElement).focus();
+      } else {
+        tdRef.current.focus();
+      }
+    }
+  }, [isFocused, tdRef.current]);
+
   return (
     <td
+      ref={tdRef}
       id={getCellId(row.key, column)}
       data-row-index={row.index}
       data-column-index={column.index}

--- a/packages/grid/src/BaseCell.tsx
+++ b/packages/grid/src/BaseCell.tsx
@@ -3,7 +3,7 @@ import "./BaseCell.css";
 import { makePrefixer } from "@jpmorganchase/uitk-core";
 import { GridCellProps } from "./GridColumn";
 import { GridColumnModel } from "./Grid";
-import { useEffect, useRef } from "react";
+import { FocusEventHandler, useRef, useState } from "react";
 
 const withBaseName = makePrefixer("uitkGridBaseCell");
 
@@ -26,17 +26,17 @@ export function BaseCell<T>(props: GridCellProps<T>) {
   } = props;
 
   const tdRef = useRef<HTMLTableCellElement>(null);
+  const [isFocusableContent, setFocusableContent] = useState<boolean>(false);
 
-  useEffect(() => {
-    if (isFocused && tdRef.current) {
+  const onFocus: FocusEventHandler<HTMLTableCellElement> = (event) => {
+    if (event.target === tdRef.current) {
       const nestedInteractive = tdRef.current.querySelector(`[tabindex="0"]`);
       if (nestedInteractive) {
         (nestedInteractive as HTMLElement).focus();
-      } else {
-        tdRef.current.focus();
+        setFocusableContent(true);
       }
     }
-  }, [isFocused, tdRef.current]);
+  };
 
   return (
     <td
@@ -60,7 +60,8 @@ export function BaseCell<T>(props: GridCellProps<T>) {
         className
       )}
       style={style}
-      tabIndex={isFocused ? 0 : -1}
+      tabIndex={isFocused && !isFocusableContent ? 0 : -1}
+      onFocus={onFocus}
     >
       <div
         className={cn(withBaseName("valueContainer"), {

--- a/packages/grid/src/Grid.tsx
+++ b/packages/grid/src/Grid.tsx
@@ -432,17 +432,6 @@ export const Grid = function Grid<T>(props: GridProps<T>) {
     scroll
   );
 
-  const focusCellElement = (rowIdx: number, colIdx: number) => {
-    setTimeout(() => {
-      const nodeToFocus = rootRef.current?.querySelector(
-        `td[data-row-index="${rowIdx}"][data-column-index="${colIdx}"]`
-      );
-      if (nodeToFocus) {
-        (nodeToFocus as HTMLElement).focus();
-      }
-    }, 0);
-  };
-
   const startEditMode = (text?: string) => {
     if (editMode || cursorRowIdx == undefined || cursorColIdx == undefined) {
       return;
@@ -478,7 +467,6 @@ export const Grid = function Grid<T>(props: GridProps<T>) {
       handler(rowData[cursorRowIdx], cursorRowIdx, value);
     }
     setEditMode(false);
-    focusCellElement(cursorRowIdx, cursorColIdx);
   };
 
   const cancelEditMode = () => {
@@ -486,9 +474,6 @@ export const Grid = function Grid<T>(props: GridProps<T>) {
       return;
     }
     setEditMode(false);
-    if (cursorRowIdx != null && cursorColIdx != null) {
-      focusCellElement(cursorRowIdx, cursorColIdx);
-    }
   };
 
   const {
@@ -521,7 +506,6 @@ export const Grid = function Grid<T>(props: GridProps<T>) {
       setCursorRowIdx(rowIdx);
       setCursorColIdx(colIdx);
       scrollToCell(rowIdx, colIdx);
-      focusCellElement(rowIdx, colIdx);
       rangeSelection.onCursorMove({ rowIdx, colIdx });
     },
     [

--- a/packages/grid/src/Grid.tsx
+++ b/packages/grid/src/Grid.tsx
@@ -432,6 +432,17 @@ export const Grid = function Grid<T>(props: GridProps<T>) {
     scroll
   );
 
+  const focusCellElement = (rowIdx: number, colIdx: number) => {
+    setTimeout(() => {
+      const nodeToFocus = rootRef.current?.querySelector(
+        `td[data-row-index="${rowIdx}"][data-column-index="${colIdx}"]`
+      );
+      if (nodeToFocus) {
+        (nodeToFocus as HTMLElement).focus();
+      }
+    }, 0);
+  };
+
   const startEditMode = (text?: string) => {
     if (editMode || cursorRowIdx == undefined || cursorColIdx == undefined) {
       return;
@@ -467,6 +478,7 @@ export const Grid = function Grid<T>(props: GridProps<T>) {
       handler(rowData[cursorRowIdx], cursorRowIdx, value);
     }
     setEditMode(false);
+    focusCellElement(cursorRowIdx, cursorColIdx);
   };
 
   const cancelEditMode = () => {
@@ -474,6 +486,9 @@ export const Grid = function Grid<T>(props: GridProps<T>) {
       return;
     }
     setEditMode(false);
+    if (cursorRowIdx != null && cursorColIdx != null) {
+      focusCellElement(cursorRowIdx, cursorColIdx);
+    }
   };
 
   const {
@@ -506,6 +521,7 @@ export const Grid = function Grid<T>(props: GridProps<T>) {
       setCursorRowIdx(rowIdx);
       setCursorColIdx(colIdx);
       scrollToCell(rowIdx, colIdx);
+      focusCellElement(rowIdx, colIdx);
       rangeSelection.onCursorMove({ rowIdx, colIdx });
     },
     [

--- a/packages/grid/src/GridColumn.tsx
+++ b/packages/grid/src/GridColumn.tsx
@@ -27,10 +27,11 @@ export interface GridCellProps<T> {
   children?: ReactNode;
 }
 
-export interface GridCellValueProps<T> {
+export interface GridCellValueProps<T, U = any> {
   row: GridRowModel<T>;
   column: GridColumnModel<T>;
-  value?: T;
+  isFocused?: boolean;
+  value?: U;
 }
 
 export interface GridHeaderValueProps<T> {

--- a/packages/grid/src/RowSelectionCheckboxCellValue.tsx
+++ b/packages/grid/src/RowSelectionCheckboxCellValue.tsx
@@ -1,27 +1,24 @@
-import { CheckboxIcon, makePrefixer } from "@jpmorganchase/uitk-core";
+import { CheckboxBase } from "@jpmorganchase/uitk-core";
 import { GridCellValueProps } from "./GridColumn";
 import { useSelectionContext } from "./SelectionContext";
-import { MouseEventHandler } from "react";
 import "./CheckboxCell.css";
 
 export function RowSelectionCheckboxCellValue<T>(props: GridCellValueProps<T>) {
-  const { row } = props;
-  const { selRowIdxs, selectRows } = useSelectionContext();
+  const { row, isFocused } = props;
+  const { selRowIdxs } = useSelectionContext();
 
   const isSelected = selRowIdxs.has(row.index);
-  const onMouseDown: MouseEventHandler<HTMLDivElement> = (event) => {
-    selectRows({ rowIndex: row.index, meta: true });
-    event.preventDefault();
-    event.stopPropagation();
-  };
 
   return (
-    <div
-      className="uitkGridCheckboxContainer"
-      data-testid="grid-row-selection-checkbox"
-      onMouseDown={onMouseDown}
-    >
-      <CheckboxIcon checked={isSelected} />
+    <div className="uitkGridCheckboxContainer">
+      <CheckboxBase
+        data-testid="grid-row-selection-checkbox"
+        inputProps={{
+          "aria-label": "Select Row",
+          tabIndex: isFocused ? 0 : -1,
+        }}
+        checked={isSelected}
+      />
     </div>
   );
 }

--- a/packages/grid/src/RowSelectionCheckboxCellValue.tsx
+++ b/packages/grid/src/RowSelectionCheckboxCellValue.tsx
@@ -2,15 +2,25 @@ import { CheckboxBase } from "@jpmorganchase/uitk-core";
 import { GridCellValueProps } from "./GridColumn";
 import { useSelectionContext } from "./SelectionContext";
 import "./CheckboxCell.css";
+import { MouseEventHandler } from "react";
+import { useCursorContext } from "./CursorContext";
 
 export function RowSelectionCheckboxCellValue<T>(props: GridCellValueProps<T>) {
-  const { row, isFocused } = props;
-  const { selRowIdxs } = useSelectionContext();
+  const { row, column, isFocused } = props;
+  const { selRowIdxs, selectRows } = useSelectionContext();
+  const { moveCursor } = useCursorContext();
 
   const isSelected = selRowIdxs.has(row.index);
 
+  const onMouseDown: MouseEventHandler<HTMLDivElement> = (event) => {
+    selectRows({ rowIndex: row.index, meta: true });
+    moveCursor(row.index, column.index);
+    event.preventDefault();
+    event.stopPropagation();
+  };
+
   return (
-    <div className="uitkGridCheckboxContainer">
+    <div className="uitkGridCheckboxContainer" onMouseDown={onMouseDown}>
       <CheckboxBase
         data-testid="grid-row-selection-checkbox"
         inputProps={{

--- a/packages/grid/src/RowSelectionRadioCellValue.tsx
+++ b/packages/grid/src/RowSelectionRadioCellValue.tsx
@@ -1,27 +1,21 @@
-import { RadioButtonIcon } from "@jpmorganchase/uitk-core";
+import { RadioButtonBase } from "@jpmorganchase/uitk-core";
 import { GridCellValueProps } from "./GridColumn";
 import { useSelectionContext } from "./SelectionContext";
-import { MouseEventHandler } from "react";
 import "./CheckboxCell.css";
 
 export function RowSelectionRadioCellValue<T>(props: GridCellValueProps<T>) {
-  const { row } = props;
-  const { selRowIdxs, selectRows } = useSelectionContext();
+  const { row, isFocused } = props;
+  const { selRowIdxs } = useSelectionContext();
 
   const isSelected = selRowIdxs.has(row.index);
-  const onMouseDown: MouseEventHandler<HTMLDivElement> = (event) => {
-    selectRows({ rowIndex: row.index });
-    event.preventDefault();
-    event.stopPropagation();
-  };
 
   return (
-    <div
-      className="uitkGridCheckboxContainer"
-      onMouseDown={onMouseDown}
-      data-testid="grid-row-selection-radiobox"
-    >
-      <RadioButtonIcon checked={isSelected} />
+    <div className="uitkGridCheckboxContainer">
+      <RadioButtonBase
+        checked={isSelected}
+        tabIndex={isFocused ? 0 : -1}
+        data-testid="grid-row-selection-radiobox"
+      />
     </div>
   );
 }

--- a/packages/grid/src/__tests__/__e2e__/Grid.cy.tsx
+++ b/packages/grid/src/__tests__/__e2e__/Grid.cy.tsx
@@ -183,18 +183,10 @@ describe("Grid", () => {
     cy.mount(<GridExample />);
 
     const checkCursorPos = (row: number, col: number) => {
-      // Column 0 has interactive elements in cells. We expect the interactive element to have focus.
-      // Other columns have no interactive elements. Focus is expected to be on the cell element.
-      if (col === 0) {
         cy.focused()
-          .parents("td")
+          .closest("td")
           .should("have.attr", "aria-rowindex", String(row + 1))
           .should("have.attr", "aria-colindex", String(col + 1));
-      } else {
-        cy.focused()
-          .should("have.attr", "aria-rowindex", String(row + 1))
-          .should("have.attr", "aria-colindex", String(col + 1));
-      }
     };
 
     // we cannot test tabbing in cypress for now

--- a/packages/grid/src/__tests__/__e2e__/Grid.cy.tsx
+++ b/packages/grid/src/__tests__/__e2e__/Grid.cy.tsx
@@ -183,9 +183,18 @@ describe("Grid", () => {
     cy.mount(<GridExample />);
 
     const checkCursorPos = (row: number, col: number) => {
-      cy.focused()
-        .should("have.attr", "aria-rowindex", String(row + 1))
-        .should("have.attr", "aria-colindex", String(col + 1));
+      // Column 0 has interactive elements in cells. We expect the interactive element to have focus.
+      // Other columns have no interactive elements. Focus is expected to be on the cell element.
+      if (col === 0) {
+        cy.focused()
+          .parents("td")
+          .should("have.attr", "aria-rowindex", String(row + 1))
+          .should("have.attr", "aria-colindex", String(col + 1));
+      } else {
+        cy.focused()
+          .should("have.attr", "aria-rowindex", String(row + 1))
+          .should("have.attr", "aria-colindex", String(col + 1));
+      }
     };
 
     // we cannot test tabbing in cypress for now
@@ -280,6 +289,7 @@ describe("Grid", () => {
 
     cy.findByText("button 1").focus().realPress("Tab");
     cy.focused()
+      .parents("td")
       .should("have.attr", "aria-colindex", "1")
       .should("have.attr", "aria-rowindex", "1");
 
@@ -288,6 +298,7 @@ describe("Grid", () => {
     cy.focused().realPress(["Shift", "Tab"]);
 
     cy.focused()
+      .parents("td")
       .should("have.attr", "aria-colindex", "1")
       .should("have.attr", "aria-rowindex", "1");
 

--- a/packages/grid/src/__tests__/__e2e__/Grid.cy.tsx
+++ b/packages/grid/src/__tests__/__e2e__/Grid.cy.tsx
@@ -183,10 +183,10 @@ describe("Grid", () => {
     cy.mount(<GridExample />);
 
     const checkCursorPos = (row: number, col: number) => {
-        cy.focused()
-          .closest("td")
-          .should("have.attr", "aria-rowindex", String(row + 1))
-          .should("have.attr", "aria-colindex", String(col + 1));
+      cy.focused()
+        .closest("td")
+        .should("have.attr", "aria-rowindex", String(row + 1))
+        .should("have.attr", "aria-colindex", String(col + 1));
     };
 
     // we cannot test tabbing in cypress for now

--- a/packages/grid/src/internal/TableRow.tsx
+++ b/packages/grid/src/internal/TableRow.tsx
@@ -105,7 +105,12 @@ export function TableRow<T>(props: TableRowProps<T>) {
             isSelected={isSelected}
             isEditable={isEditable}
           >
-            <CellValue column={column} row={row} value={value} />
+            <CellValue
+              column={column}
+              row={row}
+              value={value}
+              isFocused={isFocused}
+            />
           </Cell>
         );
       })}


### PR DESCRIPTION
Row selection cells show focus border around the interactive element within the cell (radio button or checkbox), not on the cell itself.