### PR TITLE
Improve site <title> text

### DIFF
--- a/site/docusaurus.config.js
+++ b/site/docusaurus.config.js
@@ -25,7 +25,7 @@ const favicons = {
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-  title: "Welcome to Salt",
+  title: "Salt Design System",
   tagline: `Salt is the J.P. Morgan design system, an open-source solution for building exceptional products and digital experiences in financial services and other industries. It offers you well-documented, accessibility-focused components as well as comprehensive design templates, style libraries and assets.
   Salt is the next-generation version of the established internal J.P. Morgan UI Toolkit design system, which has been used to build over 1,200 websites and applications to date.
   In time, as a full-service solution, Salt will be the vehicle for digital delivery of a universal design language—with best-in-class business patterns, content and accessibility guides, tooling and adoption resources.`,

--- a/site/src/pages/index.tsx
+++ b/site/src/pages/index.tsx
@@ -23,7 +23,7 @@ function HomepageHeader() {
     <div className={styles.heroContainer}>
       <header className={clsx("hero hero--primary", styles.heroBanner)}>
         <div className="container">
-          <h1 className={styles.heroTitle}>{siteConfig.title}</h1>
+          <h1 className={styles.heroTitle}>Welcome to Salt</h1>
           {splitTagline.map((tagline, index) => (
             <p key={index}>{tagline}</p>
           ))}
@@ -82,10 +82,7 @@ const cards: CardProps[] = [
 export default function Home(): JSX.Element {
   const { siteConfig } = useDocusaurusContext();
   return (
-    <Layout
-      title={siteConfig.title}
-      description="Description will go into a meta tag in <head />"
-    >
+    <Layout description="Description will go into a meta tag in <head />">
       <div className={styles.homepageContainer}>
         <HomepageHeader />
         <Features heading="What to expect" listItems={features} />


### PR DESCRIPTION
Previously, our site name was configured to be "Welcome to Salt" (same as the H1 _in-page_ title we use on the homepage). However, this meant that our `<title>` texts, which are displayed in browser tabs, bookmarks and search engine results weren't ideal.

For example:

* When browser tabs are narrow and the full text is truncated, you only see "Welcome...", which isn't helpful when you're trying to find the "Salt (Design System)" site in your open tabs:
![browser tab displaying the text "Welcome..."](https://user-images.githubusercontent.com/16718916/206699799-e3c49286-59d6-48f1-818f-3b295bf8a00f.png)
* The site name is appended to all page titles, meaning it appears twice on the homepage and also every other page is suffixed with "| _Welcome to_ Salt", which looks odd
![Tooltip showing homepage title as "Welcome to Salt | Welcome to Salt"](https://user-images.githubusercontent.com/16718916/206700011-d051556e-ada6-4687-9171-bc0661d8a68c.png)
![Tooltip showing homepage title as "Getting Started| Welcome to Salt"](https://user-images.githubusercontent.com/16718916/206700053-9cfc114e-1ce8-43c0-8a16-584556d7286f.png)

This PR fixes this by setting the site name to "Salt Design System" (I intentionally included the "Design System" bit to help differentiate this in search results or people's bookmarks from Salt, the seasoning :-P. It also removes the duplication of the title on the homepage.

Note that only the HTML `<title>` is affected. All in-page text is unchanged. So the homepage still displays "Welcome to Salt".

![tab displaying "Salt Design System"](https://user-images.githubusercontent.com/16718916/206700612-fa89c124-b882-4c41-97fe-85a018be0038.png)
![tab displaying "Getting Started | Salt Design System"](https://user-images.githubusercontent.com/16718916/206700640-8a7726c6-54c5-4f28-bb5d-2c882c14a3cc.png)
