### PR TITLE
Move to global id for useId

### DIFF
--- a/.changeset/healthy-spoons-sip.md
+++ b/.changeset/healthy-spoons-sip.md
@@ -1,0 +1,6 @@
+---
+"@jpmorganchase/uitk-core": patch
+"@jpmorganchase/uitk-lab": patch
+---
+
+Move to global incrementing counter for useId

--- a/packages/core/src/layout/DeckItem/DeckItem.tsx
+++ b/packages/core/src/layout/DeckItem/DeckItem.tsx
@@ -1,6 +1,6 @@
 import cx from "classnames";
 import { forwardRef, HTMLAttributes, useMemo, useRef } from "react";
-import { makePrefixer, useForkRef, useIdMemo } from "../../utils";
+import { makePrefixer, useForkRef, useId } from "../../utils";
 import { LayoutAnimation } from "../types";
 import "./DeckItem.css";
 
@@ -22,7 +22,7 @@ export const DeckItem = forwardRef<HTMLDivElement, DeckItemProps>(
       className,
       index,
       role = "group",
-      id,
+      id: idProp,
       ...rest
     },
     ref
@@ -42,7 +42,7 @@ export const DeckItem = forwardRef<HTMLDivElement, DeckItemProps>(
       `${animation || "fade"}-out`, // out-left
     ];
 
-    const deckItemId = useIdMemo(id);
+    const id = useId(idProp);
 
     return (
       <div
@@ -58,7 +58,7 @@ export const DeckItem = forwardRef<HTMLDivElement, DeckItemProps>(
         ref={useForkRef(ref, sliderRef)}
         role={role}
         tabIndex={isCurrent ? 0 : -1}
-        id={deckItemId}
+        id={id}
         {...rest}
       >
         {children}

--- a/packages/core/src/utils/useId.ts
+++ b/packages/core/src/utils/useId.ts
@@ -5,21 +5,19 @@ const maybeReactUseId: undefined | (() => string) = (React as any)[
   `${"useId"}${""}`
 ];
 
-function useIdLegacy(idOverride?: string): string {
+let globalId = BigInt(0);
+function useIdLegacy(idOverride?: string): string | undefined {
   const [defaultId, setDefaultId] = React.useState(idOverride);
   const id = idOverride || defaultId;
   React.useEffect(() => {
     if (defaultId == null) {
-      // Fallback to this default id when possible.
-      // Use the random value for client-side rendering only.
-      // We can't use it server-side.
-      setDefaultId(`uitk-${Math.round(Math.random() * 1e5)}`);
+      setDefaultId(`uitk-${++globalId}`);
     }
   }, [defaultId]);
-  return id as string;
+  return id;
 }
 
-export function useId(idOverride?: string): string {
+export function useId(idOverride?: string): string | undefined {
   if (maybeReactUseId !== undefined) {
     const reactId = maybeReactUseId();
     return idOverride ?? reactId;
@@ -32,7 +30,7 @@ export function useId(idOverride?: string): string {
 // (as with the useEffect solution). This can go away once we totally move to React 18
 export function useIdMemo(idOverride?: string): string {
   const id = React.useMemo(() => {
-    return idOverride ?? `uitk-${Math.round(Math.random() * 1e5)}`;
+    return idOverride ?? `uitk-${++globalId}`;
   }, [idOverride]);
   return id;
 }

--- a/packages/lab/src/list-deprecated/useList.ts
+++ b/packages/lab/src/list-deprecated/useList.ts
@@ -39,7 +39,7 @@ export interface ListState<
   Item = string,
   Variant extends ListSelectionVariant = "default"
 > {
-  id: string;
+  id?: string;
   focusVisible: boolean;
   selectedItem?: Variant extends ListMultiSelectionVariant ? Array<Item> : Item;
   highlightedIndex?: number;
@@ -518,7 +518,7 @@ export function useList<Item, Variant extends ListSelectionVariant>(
   };
 
   const handleMouseLeave = (event: MouseEvent<HTMLDivElement>) => {
-    if (focusVisible) {
+    if (focusVisible && id) {
       // Get the root node of the component if we have access to it otherwise default to current document
       const rootNode = (
         rootRef.current || ownerDocument(event.currentTarget)


### PR DESCRIPTION
This moves useId to a more standard way of polyfilling React's useId (taken from their RFC) and should solve the conflicts we've been seeing on the CI.